### PR TITLE
Add missing database_charset in parameters page

### DIFF
--- a/de/admin/parameters.md
+++ b/de/admin/parameters.md
@@ -18,6 +18,7 @@ parameters:
     database_path: '%kernel.root_dir%/../data/db/wallabag.sqlite'
     database_table_prefix: wallabag_
     database_socket: null
+    database_charset: utf8
     mailer_transport: smtp
     mailer_host: 127.0.0.1
     mailer_user: null

--- a/en/admin/parameters.md
+++ b/en/admin/parameters.md
@@ -17,6 +17,7 @@ parameters:
     database_path: '%kernel.root_dir%/../data/db/wallabag.sqlite'
     database_table_prefix: wallabag_
     database_socket: null
+    database_charset: utf8
     mailer_transport: smtp
     mailer_host: 127.0.0.1
     mailer_user: null

--- a/fr/admin/parameters.md
+++ b/fr/admin/parameters.md
@@ -18,6 +18,7 @@ parameters:
     database_path: '%kernel.root_dir%/../data/db/wallabag.sqlite'
     database_table_prefix: wallabag_
     database_socket: null
+    database_charset: utf8
     mailer_transport: smtp
     mailer_host: 127.0.0.1
     mailer_user: null

--- a/it/admin/parameters.md
+++ b/it/admin/parameters.md
@@ -19,6 +19,7 @@ parameters:
     database_path: '%kernel.root_dir%/../data/db/wallabag.sqlite'
     database_table_prefix: wallabag_
     database_socket: null
+    database_charset: utf8
     mailer_transport: smtp
     mailer_host: 127.0.0.1
     mailer_user: null


### PR DESCRIPTION
The `database_charset` was missing in the default `parameters.yml` file