### PR TITLE
Fixed typo for Apache 2.4 in virtual hosts install instructions

### DIFF
--- a/en/admin/installation/virtualhosts.md
+++ b/en/admin/installation/virtualhosts.md
@@ -62,7 +62,7 @@ Allow from All
 by
 
 ```apache
-Require All granted
+Require all granted
 ```
 
 After reloading or restarting Apache, you should now be able to access

--- a/fr/admin/installation/virtualhosts.md
+++ b/fr/admin/installation/virtualhosts.md
@@ -62,7 +62,7 @@ Allow from All
 par
 
 ```apache
-Require All granted
+Require all granted
 ```
 
 Après que vous ayez rechargé/redémarré Apache, vous devriez pouvoir


### PR DESCRIPTION
Fixed the Require instruction for Apache 2.4, a typo was preventing it from reloading successfully.