### PR TITLE
Update virtualhosts.md

### DIFF
--- a/de/admin/installation/virtualhosts.md
+++ b/de/admin/installation/virtualhosts.md
@@ -68,6 +68,8 @@ server {
         try_files $uri /app.php$is_args$args;
     }
     location ~ ^/app\.php(/|$) {
+        # if, for some reason, you are still using PHP 5,
+        # then replace /run/php/php7.0 by /var/run/php5
         fastcgi_pass unix:/run/php/php7.0-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;

--- a/de/admin/installation/virtualhosts.md
+++ b/de/admin/installation/virtualhosts.md
@@ -68,7 +68,7 @@ server {
         try_files $uri /app.php$is_args$args;
     }
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the

--- a/en/admin/installation/virtualhosts.md
+++ b/en/admin/installation/virtualhosts.md
@@ -83,9 +83,9 @@ server {
         try_files $uri /app.php$is_args$args;
     }
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
         # if, for some reason, you are still using PHP 5,
-        # then replace /run/php/php7.0 → /var/run/php5
+        # then replace /run/php/php7.0 by /var/run/php5
+        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the

--- a/en/admin/installation/virtualhosts.md
+++ b/en/admin/installation/virtualhosts.md
@@ -83,7 +83,9 @@ server {
         try_files $uri /app.php$is_args$args;
     }
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
+        # if, for some reason, you are still using PHP 5,
+        # then replace /run/php/php7.0 → /var/run/php5
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the

--- a/fr/admin/installation/virtualhosts.md
+++ b/fr/admin/installation/virtualhosts.md
@@ -84,9 +84,9 @@ server {
         try_files $uri /app.php$is_args$args;
     }
     location ~ ^/app\.php(/|$) {
+        # Si vous utilisez PHP 5 remplacez
+        # /run/php/php7.0 par /var/run/php5
         fastcgi_pass unix:/run/php/php7.0-fpm.sock;
-        # Si vous avez php6, pour quelque raison, remplacez
-        # /run/php/php7.0-fpm.sock par /var/run/php5-fpm.sock
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the

--- a/fr/admin/installation/virtualhosts.md
+++ b/fr/admin/installation/virtualhosts.md
@@ -84,7 +84,9 @@ server {
         try_files $uri /app.php$is_args$args;
     }
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
+        # Si vous avez php6, pour quelque raison, remplacez
+        # /run/php/php7.0-fpm.sock par /var/run/php5-fpm.sock
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the

--- a/it/admin/installation/virtualhosts.md
+++ b/it/admin/installation/virtualhosts.md
@@ -69,6 +69,8 @@ server {
         try_files $uri /app.php$is_args$args;
     }
     location ~ ^/app\.php(/|$) {
+        # if, for some reason, you are still using PHP 5,
+        # then replace /run/php/php7.0 by /var/run/php5
         fastcgi_pass unix:/run/php/php7.0-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;

--- a/it/admin/installation/virtualhosts.md
+++ b/it/admin/installation/virtualhosts.md
@@ -69,7 +69,7 @@ server {
         try_files $uri /app.php$is_args$args;
     }
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the


### PR DESCRIPTION
Nginx recipe - Modified php-fpm.socket path to use php7 instead php5. This is mandatory for Wallabag to work, otherwise you'll get a 502 Bad Gateway.