### PR TITLE
Add a step by step to log fetching error

### DIFF
--- a/en/user/errors_during_fetching.md
+++ b/en/user/errors_during_fetching.md
@@ -45,3 +45,14 @@ If wallabag failed when fetching an article, you can click on the reload
 button (the third on the below picture).
 
 ![Refetch content](../../img/user/refetch.png)
+
+## Enable log to help us identify the problem
+
+If you really can't find a way to parse the content after trying the previous 2 steps, you can enable log which will help us to find why it fails.
+
+- edit `app/config/config_prod.yml`
+- replace [in line 18](https://github.com/wallabag/wallabag/blob/master/app/config/config_prod.yml#L18) `error` to `debug`
+- `rm -rf var/cache/*`
+- empty file `var/log/prod.log`
+- reload your wallabag and refetch the content
+- paste the file `var/log/prod.log` in a new issue on GitHub

--- a/fr/user/errors_during_fetching.md
+++ b/fr/user/errors_during_fetching.md
@@ -53,3 +53,15 @@ Si wallabag échoue en récupérant l'article, vous pouvez cliquer sur le
 bouton suivant (le troisième sur l'image ci-dessous).
 
 ![Réessayer de récupérer le contenu](../../img/user/refetch.png)
+
+## Activer les logs pour faciliter l'issue du problème
+
+Si après les 2 étapes décrites ci-dessus vous n'arrivez pas à avoir le contenu de l'article, l'erreur est peut-être ailleurs.
+Dans ce cas, vous allez activer les logs sur votre instance wallabag pour nous aider à trouver ce qui ne vas pas.
+
+- éditez le fichier `app/config/config_prod.yml`
+- à [la ligne 18](https://github.com/wallabag/wallabag/blob/master/app/config/config_prod.yml#L18) mettez `error` à la place de `debug`
+- `rm -rf var/cache/*`
+- vider le contenu du fichier `var/log/prod.log`
+- recharger votre instance wallabag et recharger le contenu qui pose soucis
+- copier/coller le contenu du fichier `var/log/prod.log` dans une nouvelle issue GitHub


### PR DESCRIPTION
I though it would be a good addition to describe how to enable log for debugging a fetching error.

Following https://github.com/wallabag/wallabag/issues/3261