### PR TITLE
Add a part to check for production log

### DIFF
--- a/de/user/errors_during_fetching.md
+++ b/de/user/errors_during_fetching.md
@@ -1,16 +1,13 @@
-Fehler während des Artikelladens
-================================
+# Fehler während des Artikelladens
 
-Warum schlägt das Laden eines Artikels fehl?
---------------------------------------------
+## Warum schlägt das Laden eines Artikels fehl?
 
 Das kann verschiedene Ursachen haben:
 
 -   Netzwerkprobleme
 -   wallabag kann den Inhalt aufgrund der Websitestruktur nicht laden
 
-Wie kann ich helfen das zu beheben?
------------------------------------
+## Wie kann ich helfen das zu beheben?
 
 -   [indem du uns eine Mail mit der URL des Artikels
     sendest](mailto:hello@wallabag.org)
@@ -18,8 +15,7 @@ Wie kann ich helfen das zu beheben?
     Datei für den Artikel selbst zu beheben Du kannst [dieses
     Tool](http://siteconfig.fivefilters.org/) nutzen.
 
-Wie kann ich versuchen, einen Artikel erneut zu laden?
-------------------------------------------------------
+## Wie kann ich versuchen, einen Artikel erneut zu laden?
 
 Wenn wallabag beim Laden eines Artikels fehlschlägt, kannst du auf den
 erneut laden Button klicken (der dritte in dem unteren Bild).

--- a/en/user/errors_during_fetching.md
+++ b/en/user/errors_during_fetching.md
@@ -7,6 +7,25 @@ There may be several reasons:
 -   network problem
 -   wallabag can't fetch content due to the website structure
 
+## Check production log for debug / error message
+
+By default, if a website can't be fetched because of a request error (a 404 page, a timeout, a SSL problem, etc.) the error log message will be displayed in the `WALLABAG_DIR/var/log/prod.log` file.
+
+If you find a line starting with `graby.ERROR` during the timeframe of your test it means the request failed because of an error.
+
+Please report that error (and the whole text around in the log file) when opening an issue on GitHub.
+
+## Enable log to help us identify the problem
+
+If you can't find an error message in the log and really can't find a way to parse the content after trying the previous 2 steps, you can enable log which will help us to find why it fails.
+
+- edit `app/config/config_prod.yml`
+- replace [in line 18](https://github.com/wallabag/wallabag/blob/master/app/config/config_prod.yml#L18) `error` to `debug`
+- `rm -rf var/cache/*`
+- empty file `var/log/prod.log`
+- reload your wallabag and refetch the content
+- paste the file `var/log/prod.log` in a new issue on GitHub
+
 ## How can I help to fix that?
 
 You can try to fix this problem by yourself (so we can be focused on
@@ -35,7 +54,7 @@ Repeat until you have something ok.
 Then you can submit a pull request to
 [<https://github.com/fivefilters/ftr-site-config>](https://github.com/fivefilters/ftr-site-config)
 which is the global repo for siteconfig files.
-If you can't wait for update from fivefilters - you can place your config file into directory 
+If you can't wait for update from fivefilters - you can place your config file into directory
 `vendor/j0k3r/graby-site-config` in your wallabag main directory.
 Keep in mind these changes will be erased if you update your wallabag.
 
@@ -45,14 +64,3 @@ If wallabag failed when fetching an article, you can click on the reload
 button (the third on the below picture).
 
 ![Refetch content](../../img/user/refetch.png)
-
-## Enable log to help us identify the problem
-
-If you really can't find a way to parse the content after trying the previous 2 steps, you can enable log which will help us to find why it fails.
-
-- edit `app/config/config_prod.yml`
-- replace [in line 18](https://github.com/wallabag/wallabag/blob/master/app/config/config_prod.yml#L18) `error` to `debug`
-- `rm -rf var/cache/*`
-- empty file `var/log/prod.log`
-- reload your wallabag and refetch the content
-- paste the file `var/log/prod.log` in a new issue on GitHub

--- a/fr/user/errors_during_fetching.md
+++ b/fr/user/errors_during_fetching.md
@@ -9,7 +9,7 @@ Il peut y avoir plusieurs raisons :
 
 ## Vérifier les logs de production pour les messages d'erreurs ou de debug
 
-Par défaut, si un site ne peut pas être correctemetn parsé à cause d'une erreur dans la requête (une page inexistante, un temps de réponse trop long, etc.) un message d'erreur sera affiché dans le fichier `WALLABAG_DIR/var/log/prod.log`.
+Par défaut, si un site ne peut pas être correctement parsé à cause d'une erreur dans la requête (une page inexistante, un temps de réponse trop long, etc.) un message d'erreur sera affiché dans le fichier `WALLABAG_DIR/var/log/prod.log`.
 
 Si vous voyez une ligne qui commence par `graby.ERROR` et qui correspond à votre période de test, c'est que la requête a échoué à cause d'une erreur.
 
@@ -18,14 +18,14 @@ Merci d'indiquer tout le passage correspondant à l'erreur dans l'issue que vous
 ## Activer les logs pour faciliter l'issue du problème
 
 Si après les 2 étapes décrites ci-dessus vous n'arrivez pas à avoir le contenu de l'article, l'erreur est peut-être ailleurs.
-Dans ce cas, vous allez activer les logs sur votre instance wallabag pour nous aider à trouver ce qui ne vas pas.
+Dans ce cas, vous allez activer les logs sur votre instance wallabag pour nous aider à trouver ce qui ne va pas.
 
 - éditez le fichier `app/config/config_prod.yml`
 - à [la ligne 18](https://github.com/wallabag/wallabag/blob/master/app/config/config_prod.yml#L18) mettez `error` à la place de `debug`
 - `rm -rf var/cache/*`
-- vider le contenu du fichier `var/log/prod.log`
-- recharger votre instance wallabag et recharger le contenu qui pose soucis
-- copier/coller le contenu du fichier `var/log/prod.log` dans une nouvelle issue GitHub
+- videz le contenu du fichier `var/log/prod.log`
+- rechargez votre instance wallabag et rechargez le contenu qui pose souci
+- copiez/collez le contenu du fichier `var/log/prod.log` dans une nouvelle issue GitHub
 
 ## Comment puis-je aider pour réparer ça ?
 

--- a/fr/user/errors_during_fetching.md
+++ b/fr/user/errors_during_fetching.md
@@ -1,17 +1,33 @@
-Erreur durant la récupération des articles
-==========================================
+# Erreur durant la récupération des articles
 
-Pourquoi la récupération des articles échoue ?
-----------------------------------------------
+## Pourquoi la récupération des articles échoue ?
 
 Il peut y avoir plusieurs raisons :
 
 -   problème de connexion internet
--   wallabag ne peut pas récupérer le contenu à cause de la structure du
-    site web
+-   wallabag ne peut pas récupérer le contenu à cause de la structure du site web
 
-Comment puis-je aider pour réparer ça ?
----------------------------------------
+## Vérifier les logs de production pour les messages d'erreurs ou de debug
+
+Par défaut, si un site ne peut pas être correctemetn parsé à cause d'une erreur dans la requête (une page inexistante, un temps de réponse trop long, etc.) un message d'erreur sera affiché dans le fichier `WALLABAG_DIR/var/log/prod.log`.
+
+Si vous voyez une ligne qui commence par `graby.ERROR` et qui correspond à votre période de test, c'est que la requête a échoué à cause d'une erreur.
+
+Merci d'indiquer tout le passage correspondant à l'erreur dans l'issue que vous ouvrirez sur GitHub.
+
+## Activer les logs pour faciliter l'issue du problème
+
+Si après les 2 étapes décrites ci-dessus vous n'arrivez pas à avoir le contenu de l'article, l'erreur est peut-être ailleurs.
+Dans ce cas, vous allez activer les logs sur votre instance wallabag pour nous aider à trouver ce qui ne vas pas.
+
+- éditez le fichier `app/config/config_prod.yml`
+- à [la ligne 18](https://github.com/wallabag/wallabag/blob/master/app/config/config_prod.yml#L18) mettez `error` à la place de `debug`
+- `rm -rf var/cache/*`
+- vider le contenu du fichier `var/log/prod.log`
+- recharger votre instance wallabag et recharger le contenu qui pose soucis
+- copier/coller le contenu du fichier `var/log/prod.log` dans une nouvelle issue GitHub
+
+## Comment puis-je aider pour réparer ça ?
 
 Vous pouvez essayer de résoudre ce problème vous même (comme ça, nous
 restons concentrés pour améliorer wallabag au lieu d'écrire ces fichiers
@@ -44,24 +60,9 @@ Ensuite, vous pouvez créer une pull request ici
 qui est le projet principal pour stocker les fichiers de configuration.
 Si vous ne voulez pas attendre que votre PR soit mergée, vous pouvez mettre vos fichiers de config dans le répertoire `vendor/j0k3r/graby-site-config` de votre wallabag. Mais ces modifications seront supprimées quand vous mettez à jour wallabag.
 
-
-
-Comment puis-je réessayer de récupérer le contenu ?
----------------------------------------------------
+## Comment puis-je réessayer de récupérer le contenu ?
 
 Si wallabag échoue en récupérant l'article, vous pouvez cliquer sur le
 bouton suivant (le troisième sur l'image ci-dessous).
 
 ![Réessayer de récupérer le contenu](../../img/user/refetch.png)
-
-## Activer les logs pour faciliter l'issue du problème
-
-Si après les 2 étapes décrites ci-dessus vous n'arrivez pas à avoir le contenu de l'article, l'erreur est peut-être ailleurs.
-Dans ce cas, vous allez activer les logs sur votre instance wallabag pour nous aider à trouver ce qui ne vas pas.
-
-- éditez le fichier `app/config/config_prod.yml`
-- à [la ligne 18](https://github.com/wallabag/wallabag/blob/master/app/config/config_prod.yml#L18) mettez `error` à la place de `debug`
-- `rm -rf var/cache/*`
-- vider le contenu du fichier `var/log/prod.log`
-- recharger votre instance wallabag et recharger le contenu qui pose soucis
-- copier/coller le contenu du fichier `var/log/prod.log` dans une nouvelle issue GitHub

--- a/it/user/errors_during_fetching.md
+++ b/it/user/errors_during_fetching.md
@@ -1,8 +1,6 @@
-Errori durante l'ottenimento degli articoli
-===========================================
+# Errori durante l'ottenimento degli articoli
 
-Perché l'ottenimento di un articolo fallisce?
----------------------------------------------
+## Perché l'ottenimento di un articolo fallisce?
 
 Ci possono essere varie ragioni:
 
@@ -38,8 +36,7 @@ Potete poi inviare una pull request a
 [<https://github.com/fivefilters/ftr-site-config>](https://github.com/fivefilters/ftr-site-config)
 il quale é il repository ufficiale per i file siteconfig.
 
-Come posso provare a riottenere questo articolo?
-------------------------------------------------
+## Come posso provare a riottenere questo articolo?
 
 Se wallabag ha fallito a ottenere l'articolo, potete cliccare sul
 bottone di ricaricamento (il terzo bottone nella figura sottostante).


### PR DESCRIPTION
graby should now [log an error message](https://github.com/j0k3r/graby/pull/114) when the request fail. When it does that, the whole logs related to the request will be written in the production log. It might help debugging the problem.

Also, I moved some part of the error documentation so user will have to check for error message in production log, then enable dev log and finally try to fix the problem by writing a siteconfig.

What do you think about that?