### PR TITLE
add a note on when to use which docker config

### DIFF
--- a/en/developer/docker.md
+++ b/en/developer/docker.md
@@ -1,8 +1,14 @@
 Run wallabag in docker-compose
 ==============================
 
+This document describes the usage of docker for wallabag development
+purposes. In order to run wallabag in production, please use the
+[official docker-composer configuration
+provided](https://github.com/wallabag/docker).
+
 In order to run your own development instance of wallabag, you may want
-to use the pre-configured docker compose files.
+to use the pre-configured docker compose files provided along in the
+wallabag repository.
 
 Requirements
 ------------


### PR DESCRIPTION
i wanted to add a note for docker usage since we have two docker configs. offical one and the one in wallabag repo being used in development.

If it is okay for you to add this note, we can also translate it

PS: i created this commit at my fork of this repo since i am not allowed to create a branch at this repo anymore. this worked in past for me.