### PR TITLE
Updated documentation for 2.3 install / upgrade

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -9,7 +9,7 @@ The main documentation for this application is organized into multiple sections:
 
 -   user-related docs
 -   apps-related docs
--   administator-realted docs
+-   administator-related docs
 -   developer-related docs
 
 The documentation is available in other languages:

--- a/en/admin/installation/installation.md
+++ b/en/admin/installation/installation.md
@@ -9,14 +9,8 @@ git clone https://github.com/wallabag/wallabag.git
 cd wallabag && make install
 ```
 
-To start PHP's build-in server and test if everything did install
-correctly, you can do:
-
-```bash
-make run
-```
-
-And access wallabag at <http://yourserverip:8000>
+Now, read the following documentation to create your virtual host, then
+access your wallabag.
 
 To define parameters with environment variables, you have to set these
 variables with `SYMFONY__` prefix. For example,
@@ -26,10 +20,8 @@ documentation](http://symfony.com/doc/current/cookbook/configuration/external_pa
 ## On shared hosting
 
 We provide a package with all dependencies inside. The default
-configuration uses SQLite for the database. If you want to change these
+configuration uses MySQL for the database. If you want to change these
 settings, please edit `app/config/parameters.yml`.
-
-We already created a user: login and password are `wallabag`.
 
 With this package, wallabag doesn't check for mandatory extensions used
 in the application (theses checks are made during `composer install`
@@ -42,12 +34,24 @@ wget https://wllbg.org/latest-v2-package && tar xvf latest-v2-package
 ```
 
 You will find the [md5 hash of the latest package on our
-website](https://static.wallabag.org/releases/).
+website](https://wallabag.org/en#download).
 
 Now, read the following documentation to create your virtual host, then
-access your wallabag. If you changed the database configuration to use
-MySQL or PostgreSQL, you need to create a user via this command
-`php bin/console wallabag:install --env=prod`.
+access your wallabag.
+
+To create a new user, please use the register form. Then, in order to have admin
+permissions, please run this query in your favorite DMBS (by replacing `1` with
+the id for this new user):
+
+```sql
+UPDATE wallabag_user SET roles = 'a:2:{i:0;s:9:"ROLE_USER";i:1;s:16:"ROLE_SUPER_ADMIN";}' where id = 1;
+```
+
+## Usage of wallabag.it
+
+[wallabag.it](https://wallabag.it) is a paid service to use wallabag without installing it on a web server.
+
+This service always ships the latest release of wallabag. [You can create your account here](https://app.wallabag.it/). Try it for free: you'll get a 14-day free trial with no limitation (no credit card information required).
 
 ## Installation with Docker
 

--- a/en/admin/installation/requirements.md
+++ b/en/admin/installation/requirements.md
@@ -1,6 +1,6 @@
 # Requirements
 
-wallabag is compatible with **PHP >= 5.6**, including PHP 7.
+wallabag is compatible with **PHP >= 5.6**, including PHP 7.1.
 
 > **[info] Information**
 >
@@ -42,7 +42,7 @@ wallabag uses PDO to connect to the database, so you'll need one of the
 following:
 
 -   pdo_mysql
--   pdo_sqlite
 -   pdo_pgsql
+-   pdo_sqlite
 
 and its corresponding database server.

--- a/en/admin/parameters.md
+++ b/en/admin/parameters.md
@@ -84,7 +84,7 @@ parameters:
 | fosuser_confirmation | true to send a confirmation by email for each registration | true |
 | from_email | email address used in From: field in each email | no-reply@wallabag.org |
 | rss_limit | item limit for RSS feeds | 50 |
-| domain_name | Full URL of your wallabag instance (without the trailing slash) | https://your-wallabag-url-instance.com |
+| domain_name (**new in 2.3.0**) | Full URL of your wallabag instance (without the trailing slash) | https://your-wallabag-url-instance.com |
 
 ## RabbitMQ options
 

--- a/en/admin/query-upgrade-22-23.md
+++ b/en/admin/query-upgrade-22-23.md
@@ -1,0 +1,147 @@
+# MySQL
+
+```sql
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('share_scuttle', '1', 'entry');
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('scuttle_url', 'http://scuttle.org', 'entry');
+
+ALTER TABLE wallabag_entry ADD published_at DATETIME DEFAULT NULL, ADD published_by LONGTEXT DEFAULT NULL;
+
+ALTER TABLE wallabag_entry DROP is_public;
+
+DELETE FROM wallabag_craue_config_setting WHERE name = 'download_pictures';
+
+CREATE TABLE wallabag_site_credential (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, host VARCHAR(255) NOT NULL, username LONGTEXT NOT NULL, password LONGTEXT NOT NULL, createdAt DATETIME NOT NULL, INDEX idx_user (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB;
+ALTER TABLE wallabag_site_credential ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES wallabag_user (id);
+
+ALTER TABLE wallabag_user CHANGE username username VARCHAR(180) NOT NULL;
+ALTER TABLE wallabag_user CHANGE username_canonical username_canonical VARCHAR(180) NOT NULL;
+ALTER TABLE wallabag_user CHANGE email email VARCHAR(180) NOT NULL;
+ALTER TABLE wallabag_user CHANGE email_canonical email_canonical VARCHAR(180) NOT NULL;
+
+ALTER TABLE wallabag_entry ADD headers LONGTEXT DEFAULT NULL;
+
+ALTER TABLE wallabag_annotation MODIFY quote TEXT NOT NULL;
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('api_user_registration', '0', 'api');
+
+DELETE FROM wallabag_craue_config_setting WHERE name = 'wallabag_url';
+
+UPDATE wallabag_tag SET label = LOWER(label);
+
+ALTER TABLE wallabag_entry ADD starred_at DATETIME DEFAULT NULL;
+
+UPDATE wallabag_entry SET reading_time = 0 WHERE reading_time IS NULL;
+ALTER TABLE wallabag_entry CHANGE reading_time reading_time INT(11) NOT NULL;
+
+ALTER TABLE wallabag_entry ADD origin_url LONGTEXT DEFAULT NULL;
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('store_article_headers', '0', 'entry');
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('shaarli_share_origin_url', '0', 'entry');
+```
+
+# PostgreSQL
+
+```sql
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('share_scuttle', '1', 'entry');
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('scuttle_url', 'http://scuttle.org', 'entry');
+
+ALTER TABLE wallabag_entry ADD published_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL;
+ALTER TABLE wallabag_entry ADD published_by TEXT DEFAULT NULL;
+
+ALTER TABLE wallabag_entry DROP is_public;
+
+DELETE FROM wallabag_craue_config_setting WHERE name = 'download_pictures';
+
+CREATE SEQUENCE site_credential_id_seq INCREMENT BY 1 MINVALUE 1 START 1;
+CREATE TABLE wallabag_site_credential (id SERIAL NOT NULL, user_id INT NOT NULL, host VARCHAR(255) NOT NULL, username TEXT NOT NULL, password TEXT NOT NULL, createdAt TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id));
+CREATE INDEX idx_user ON wallabag_site_credential (user_id);
+ALTER TABLE wallabag_site_credential ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES wallabag_user (id) NOT DEFERRABLE INITIALLY IMMEDIATE;
+
+ALTER TABLE wallabag_entry ADD headers TEXT DEFAULT NULL;
+
+ALTER TABLE wallabag_annotation ALTER COLUMN quote TYPE TEXT;
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('api_user_registration', '0', 'api');
+
+DELETE FROM wallabag_craue_config_setting WHERE name = 'wallabag_url';
+
+UPDATE wallabag_tag SET label = LOWER(label);
+
+ALTER TABLE wallabag_entry ADD starred_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL;
+
+UPDATE wallabag_entry SET reading_time = 0 WHERE reading_time IS NULL;
+ALTER TABLE wallabag_entry ALTER COLUMN reading_time SET NOT NULL;
+
+ALTER TABLE wallabag_entry ADD origin_url TEXT DEFAULT NULL;
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('store_article_headers', '0', 'entry');
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('shaarli_share_origin_url', '0', 'entry');
+
+
+```
+
+# SQLite
+
+```sql
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('share_scuttle', '1', 'entry');
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('scuttle_url', 'http://scuttle.org', 'entry');
+
+ALTER TABLE wallabag_entry ADD COLUMN published_at DATETIME DEFAULT NULL;
+ALTER TABLE wallabag_entry ADD COLUMN published_by CLOB DEFAULT NULL;
+
+DROP INDEX uid;
+DROP INDEX created_at;
+DROP INDEX IDX_F4D18282A76ED395;
+CREATE TEMPORARY TABLE __temp__wallabag_entry AS SELECT id, user_id, uid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, http_status FROM wallabag_entry;
+DROP TABLE wallabag_entry;
+CREATE TABLE wallabag_entry (id INTEGER NOT NULL, user_id INTEGER DEFAULT NULL, uid VARCHAR(23) DEFAULT NULL COLLATE BINARY, title CLOB DEFAULT NULL COLLATE BINARY, url CLOB DEFAULT NULL COLLATE BINARY, is_archived BOOLEAN NOT NULL, is_starred BOOLEAN NOT NULL, content CLOB DEFAULT NULL COLLATE BINARY, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, mimetype CLOB DEFAULT NULL COLLATE BINARY, language CLOB DEFAULT NULL COLLATE BINARY, reading_time INTEGER DEFAULT NULL, domain_name CLOB DEFAULT NULL COLLATE BINARY, preview_picture CLOB DEFAULT NULL COLLATE BINARY, http_status VARCHAR(3) DEFAULT NULL COLLATE BINARY, PRIMARY KEY(id));
+INSERT INTO wallabag_entry (id, user_id, uid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, http_status) SELECT id, user_id, uid, title, url, is_archived, is_starred, content, created_at, updated_at, mimetype, language, reading_time, domain_name, preview_picture, http_status FROM __temp__wallabag_entry;
+DROP TABLE __temp__wallabag_entry;
+CREATE INDEX uid ON wallabag_entry (uid);
+CREATE INDEX created_at ON wallabag_entry (created_at);
+CREATE INDEX IDX_F4D18282A76ED395 ON wallabag_entry (user_id);
+
+DELETE FROM wallabag_craue_config_setting WHERE name = 'download_pictures';
+
+CREATE TABLE wallabag_site_credential (id INTEGER NOT NULL, user_id INTEGER NOT NULL, host VARCHAR(255) NOT NULL, username CLOB NOT NULL, password CLOB NOT NULL, createdAt DATETIME NOT NULL, PRIMARY KEY(id));
+CREATE INDEX idx_user ON wallabag_site_credential (user_id);
+
+ALTER TABLE wallabag_entry ADD COLUMN headers CLOB DEFAULT NULL;
+
+CREATE TEMPORARY TABLE __temp__wallabag_annotation AS
+SELECT id, user_id, entry_id, text, created_at, updated_at, quote, ranges
+FROM wallabag_annotation;
+DROP TABLE wallabag_annotation;
+CREATE TABLE wallabag_annotation
+(
+id INTEGER PRIMARY KEY NOT NULL,
+user_id INTEGER DEFAULT NULL,
+entry_id INTEGER DEFAULT NULL,
+text CLOB NOT NULL,
+created_at DATETIME NOT NULL,
+updated_at DATETIME NOT NULL,
+quote CLOB NOT NULL,
+ranges CLOB NOT NULL,
+CONSTRAINT FK_A7AED006A76ED395 FOREIGN KEY (user_id) REFERENCES wallabag_user (id),
+CONSTRAINT FK_A7AED006BA364942 FOREIGN KEY (entry_id) REFERENCES wallabag_entry (id) ON DELETE CASCADE
+);
+CREATE INDEX IDX_A7AED006A76ED395 ON wallabag_annotation (user_id);
+CREATE INDEX IDX_A7AED006BA364942 ON wallabag_annotation (entry_id);
+INSERT INTO wallabag_annotation (id, user_id, entry_id, text, created_at, updated_at, quote, ranges) SELECT id, user_id, entry_id, text, created_at, updated_at, quote, ranges
+FROM __temp__wallabag_annotation;
+DROP TABLE __temp__wallabag_annotation;
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('api_user_registration', '0', 'api');
+
+DELETE FROM wallabag_craue_config_setting WHERE name = 'wallabag_url';
+
+ALTER TABLE wallabag_entry ADD COLUMN starred_at DATETIME DEFAULT NULL;
+
+ALTER TABLE wallabag_entry ADD COLUMN origin_url CLOB DEFAULT NULL;
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('store_article_headers', '0', 'entry');
+
+INSERT INTO wallabag_craue_config_setting (name, value, section) VALUES ('shaarli_share_origin_url', '0', 'entry');
+```

--- a/en/admin/upgrade.md
+++ b/en/admin/upgrade.md
@@ -2,64 +2,21 @@
 
 You will find here different ways to upgrade your wallabag:
 
--   [from 2.1.x to 2.2.x](#upgrading-from-2-1-x-to-2-2-x)
--   [from 2.0.x to 2.1.1](#upgrade-from-2-0-x-to-2-1-1)
--   [from 1.x to 2.x](#from-wallabag-1-x)
+-   [from 2.2.x to 2.3.x](#upgrading-from-22x-to-23x)
+-   [from 2.x.y to 2.3.x](#upgrading-from-2xy-to-23x)
+-   [from 1.x to 2.x](#from-wallabag-1x)
 
-## Upgrading from 2.1.x to 2.2.x
+## Upgrading from 2.2.x to 2.3.x
 
 ### Upgrade on a dedicated web server
 
-**From 2.1.x:**
+If your current installation is < 2.2.x, please upgrade your instance to 2.2 before.
 
-```bash
-make update
-php bin/console doctrine:migrations:migrate --no-interaction -e=prod
-```
-
-**From 2.2.0:**
+**From 2.2.x:**
 
 ```bash
 make update
 ```
-
-#### Explanations about database migrations
-
-During the update, we execute database migrations.
-
-All the database migrations are stored in `app/DoctrineMigrations`. You
-can execute each migration individually:
-`bin/console doctrine:migrations:execute 20161001072726 --env=prod`.
-
-You can also cancel each migration individually:
-`bin/console doctrine:migrations:execute 20161001072726 --down --env=prod`.
-
-Here is the migrations list for 2.1.x to 2.2.0 release:
-
--   `20161001072726`: added foreign keys for account resetting
--   `20161022134138`: converted database to `utf8mb4` encoding (for
-    MySQL only)
--   `20161024212538`: added `user_id` column on `oauth2_clients` to
-    prevent users to delete API clients from other users
--   `20161031132655`: added the internal setting to enable/disable
-    downloading pictures
--   `20161104073720`: added `created_at` index on `entry` table
--   `20161106113822`: added `action_mark_as_read` field on `config`
-    table
--   `20161117071626`: added the internal setting to share articles to
-    unmark.it
--   `20161118134328`: added `http_status` field on `entry` table
--   `20161122144743`: added the internal setting to enable/disable
-    fetching articles with paywall
--   `20161122203647`: dropped `expired` and `credentials_expired` fields
-    on `user` table
--   `20161128084725`: added `list_mode` field on `config` table
--   `20161128131503`: dropped `locked`, `credentials_expire_at` and
-    `expires_at` fields on `user` table
--   `20161214094402`: renamed `uuid` to `uid` on `entry` table
--   `20161214094403`: added `uid` index on `entry` table
--   `20170127093841`: added `is_starred` and `is_archived` indexes on
-    `entry` table
 
 ### Upgrade on a shared hosting
 
@@ -72,7 +29,7 @@ wget https://wllbg.org/latest-v2-package && tar xvf latest-v2-package
 ```
 
 You will find the [md5 hash of the latest package on our
-website](https://static.wallabag.org/releases/).
+website](https://wallabag.org/en#download).
 
 Extract the archive in your wallabag folder and replace
 `app/config/parameters.yml` with yours.
@@ -90,63 +47,54 @@ You must run some SQL queries to upgrade your database. We assume that the table
 
 You may encounter issues with indexes names: if so, please change queries with the correct index name.
 
-[You can find all the queries here](query-upgrade-21-22.md).
+[You can find all the queries here](query-upgrade-22-23.md).
 
-## Upgrade from 2.0.x to 2.1.1
+### Explanations about database migrations
 
-Before this migration, if you configured the Pocket import by adding your consumer key in Internal settings, please do a backup of it: you'll have to add it into the Config page after the upgrade.
+During the update, we execute database migrations.
 
-### Upgrade on a dedicated web server
+All the database migrations are stored in `app/DoctrineMigrations`. You
+can execute each migration individually:
+`bin/console doctrine:migrations:execute 20161001072726 --env=prod`.
 
-```bash
-rm -rf var/cache/*
-git fetch origin
-git fetch --tags
-git checkout 2.1.1 --force
-SYMFONY_ENV=prod composer install --no-dev -o --prefer-dist
-php bin/console doctrine:migrations:migrate --env=prod
-php bin/console cache:clear --env=prod
-```
+You can also cancel each migration individually:
+`bin/console doctrine:migrations:execute 20161001072726 --down --env=prod`.
 
-### Upgrade on a shared hosting
+Here is the migrations list for 2.2.x to 2.3.x release:
 
-Backup your `app/config/parameters.yml` file.
+-   `20170327194233`: added the internal setting to share articles to
+    Scuttle
+-   `20170405182620`: added `published_at` and `published_by` fields on
+    `entry` table
+-   `20170407200919`: removed useless `is_public` field on `entry` table
+-   `20170420134133`: removed useless `download_pictures` value in
+    `craue_config_setting` table
+-   `20170501115751`: added `site_credential` table to store username / password
+    for websites with authentication
+-   `20170510082609`: changed length for username, username_canonical, email and
+    email_canonical fields in `user` table
+-   `20170511115400`: added `headers` field on `entry` table
+-   `20170511211659`: increased length of `quote` column on `annotation` table
+-   `20170602075214`: added the internal setting to create user via the API
+-   `20170606155640`: removed useless `wallabag_url` value in
+    `craue_config_setting` table
+-   `20170719231144`: changed tags to lowercase
+-   `20170824113337`: added `starred_at` field on `entry` table
+-   `20171008195606`: changed `reading_time` field to prevent null value
+-   `20171105202000`: added `origin_url` field on `entry` table
+-   `20171120163128`: added the internal setting to enable the storage of
+    article headers
+-   `20171125164500`: added the internal setting to enable the usage of the origin URL in shaarli sharing
 
-Download the 2.1.1 release of wallabag:
+## Upgrading from 2.x.y to 2.3.x
 
-```bash
-wget http://framabag.org/wallabag-release-2.1.1.tar.gz && tar xvf wallabag-release-2.1.1.tar.gz
-```
+If your wallabag instance is < 2.2.0, there is no automatic script. You need to:
 
-(md5 hash of the 2.1.1 package: `9584a3b60a2b2a4de87f536548caac93`)
+-   export your data
+-   install wallabag 2.3.x ([read the installation documentation](./installation/))
+-   import data in this fresh installation ([read the import documentation](../user/import/) )
 
-Extract the archive in your wallabag folder and replace
-`app/config/parameters.yml` with yours.
-
-Please check that your `app/config/parameters.yml` contains all the
-required parameters. You can find [here a documentation about
-parameters](./parameters.md).
-
-If you use SQLite, you must also copy your `data/` folder inside the new
-installation.
-
-Empty `var/cache` folder.
-
-You must run some SQL queries to upgrade your database. We assume that
-the table prefix is `wallabag_` and the database server is a MySQL one:
-
-```sql
-ALTER TABLE `wallabag_entry` ADD `uuid` LONGTEXT DEFAULT NULL;
-INSERT INTO `wallabag_craue_config_setting` (`name`, `value`, `section`) VALUES ('share_public', '1', 'entry');
-ALTER TABLE `wallabag_oauth2_clients` ADD name longtext COLLATE 'utf8_unicode_ci' DEFAULT NULL;
-INSERT INTO `wallabag_craue_config_setting` (`name`, `value`, `section`) VALUES ('import_with_redis', '0', 'import');
-INSERT INTO `wallabag_craue_config_setting` (`name`, `value`, `section`) VALUES ('import_with_rabbitmq', '0', 'import');
-ALTER TABLE `wallabag_config` ADD `pocket_consumer_key` VARCHAR(255) DEFAULT NULL;
-DELETE FROM `wallabag_craue_config_setting` WHERE `name` = 'pocket_consumer_key';
-```
-
-From wallabag 1.x
------------------
+## From wallabag 1.x
 
 There is no automatic script to update from wallabag 1.x to wallabag
 2.x. You need to:


### PR DESCRIPTION
Tada. 

I tried SQLite, MySQL and Postgresql upgrades, from 2.2.3 to 2.3.0. All is fine. 
All the queries are OK. 

We need :fr:, :de: and :it: too, but I think that we should merge this first PR for our users. 

Fix https://github.com/wallabag/wallabag/issues/3493