### PR TITLE
hint about Authorization header when using Apache with PHP-FPM

### DIFF
--- a/en/admin/installation/virtualhosts.md
+++ b/en/admin/installation/virtualhosts.md
@@ -2,7 +2,7 @@
 
 ## Configuration on Apache
 
-Do not forget to active the *rewrite* mod of Apache
+Do not forget to activate the *rewrite* mod of Apache:
 
 ```bash
 a2enmod rewrite && systemctl reload apache2
@@ -51,7 +51,7 @@ you want to use PHP as an Apache module, here's a vhost for wallabag:
 
 Note for Apache 2.4, in the section
 &lt;Directory /var/www/wallabag/web&gt; you have to replace the
-directives :
+directives:
 
 ```apache
 AllowOverride None

--- a/en/admin/installation/virtualhosts.md
+++ b/en/admin/installation/virtualhosts.md
@@ -68,6 +68,25 @@ Require all granted
 After reloading or restarting Apache, you should now be able to access
 wallabag at <http://domain.tld>.
 
+### PHP-FPM instead of mod_php
+
+If you use PHP-FPM (via mod_proxy_fcgi or similar) then Apache must be
+instructed to *keep* the Authorization header in requests for the API to work.
+In Apache versions `>= 2.4.13` place the following in the section `<Directory
+/var/www/wallabag/web>`:
+
+```apache
+CGIPassAuth On
+```
+
+In older Apache versions we have to set the header value as environment
+variable for the CGI process. For example, with mod_proxy_fcgi the following
+works, when placed somewhere next to the proxy definition:
+
+```apache
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+```
+
 ## Configuration on Nginx
 
 Assuming you installed wallabag in the `/var/www/wallabag` folder,

--- a/fr/admin/installation/virtualhosts.md
+++ b/fr/admin/installation/virtualhosts.md
@@ -68,6 +68,20 @@ Require all granted
 Après que vous ayez rechargé/redémarré Apache, vous devriez pouvoir
 avoir accès à wallabag à l'adresse <http://domain.tld>.
 
+### Utilisation de PHP-FPM au lieu de `mod_php`
+
+Si vous utilisez PHP-FPM (via `mod_proxy_fcgi` ou similaire), il faut indiquer à Apache de *conserver* l'en-tête `Authorization` dans les requêtes pour que l'API fonctionne. Dans les versions d'Apache `>= 2.4.13` ajoutez dans la section `<Directory /var/www/wallabag/web>` :
+
+```apache
+CGIPassAuth On
+```
+
+Dans les versions d'Apache `< 2.4.13`, il faut créer une variable d'environnement pour le processus CGI. Par exemple, avec `mod_proxy_fcgi`, on peut ajouter à côté de la définition du proxy :
+
+```apache
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+```
+
 ### Configuration avec Nginx
 
 En imaginant que vous vouliez installer wallabag dans le dossier


### PR DESCRIPTION
I have added a description about how to correctly pass Authorization header to PHP-FPM in Apache (s. wallabag/wallabag#2768.

So far only in English...