### PR TITLE
Warning about virtualhosts

### DIFF
--- a/en/admin/installation/virtualhosts.md
+++ b/en/admin/installation/virtualhosts.md
@@ -1,15 +1,18 @@
 # Virtual hosts
 
+> **[info] Setup directory**
+>
+> We assume that wallabag was installed in the `/var/www/wallabag` folder.
+
+
+> **[warning] Warning**
+>
+> The following configurations are given as examples, assuming that wallabag will be directly accessed at the root of `domain.tld` (or a `wallabag.domain.tld` subdomain).
+> Installation in folders can work, but is not supported by the maintainers.
+
 ## Configuration on Apache
 
-Do not forget to activate the *rewrite* mod of Apache:
-
-```bash
-a2enmod rewrite && systemctl reload apache2
-```
-
-Assuming you install wallabag in the `/var/www/wallabag` folder and that
-you want to use PHP as an Apache module, here's a vhost for wallabag:
+### Using Apache and mod_php
 
 ```apache
 <VirtualHost *:80>
@@ -49,9 +52,13 @@ you want to use PHP as an Apache module, here's a vhost for wallabag:
 </VirtualHost>
 ```
 
-Note for Apache 2.4, in the section
-&lt;Directory /var/www/wallabag/web&gt; you have to replace the
-directives:
+> **[warning]** _Rewrite_ mod
+>
+> Do not forget to activate the *rewrite* mod of Apache:
+> `a2enmod rewrite && systemctl reload apache2`
+
+
+Note for Apache 2.4, in the section `<Directory /var/www/wallabag/web>`, you have to replace the directives:
 
 ```apache
 AllowOverride None
@@ -65,10 +72,9 @@ by
 Require all granted
 ```
 
-After reloading or restarting Apache, you should now be able to access
-wallabag at <http://domain.tld>.
+After reloading or restarting Apache, you should now be able to access wallabag at <http://domain.tld>.
 
-### PHP-FPM instead of mod_php
+### Using Apache and PHP-FPM
 
 If you use PHP-FPM (via mod_proxy_fcgi or similar) then Apache must be
 instructed to *keep* the Authorization header in requests for the API to work.
@@ -88,9 +94,6 @@ SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 ```
 
 ## Configuration on Nginx
-
-Assuming you installed wallabag in the `/var/www/wallabag` folder,
-here's the recipe for wallabag :
 
 ```nginx
 server {
@@ -142,9 +145,7 @@ line in your nginx configuration
 
 ## Configuration on lighttpd
 
-Assuming you install wallabag in the `/var/www/wallabag` folder, here's
-the recipe for wallabag (edit your `lighttpd.conf` file and paste this
-configuration into it):
+Edit your `lighttpd.conf` file and paste this configuration into it:
 
 ```lighttpd
 server.modules = (
@@ -181,10 +182,10 @@ url.rewrite-if-not-file = (
 
 ## Configuration on Caddy
 
-For caddy server configuration might be just like this (assuming wallabag installation folder is `/var/www/wallabag`):
+For caddy server, configuration might be:
 
 ```caddy
-yourdomain.ru {
+domain.tld {
   root /var/www/wallabag/web
   fastcgi / /var/run/php7-fpm.sock php {
     index app.php
@@ -198,4 +199,4 @@ yourdomain.ru {
 }
 ```
 
-You can also add `push` directive for http/2 and `gzip` for compression. Tested with caddy v0.10.4
+You can also add `push` directive for http/2 and `gzip` for compression. Tested with caddy `=v0.10.4`.

--- a/fr/admin/installation/virtualhosts.md
+++ b/fr/admin/installation/virtualhosts.md
@@ -1,16 +1,18 @@
 # Virtual hosts
 
+> **[info] Répertoire d'installation**
+>
+> Nous supposons que wallabag a été installé dans le répertoire `/var/www/wallabag`.
+
+
+> **[warn] Avertissement**
+>
+> Les exemples de configuration ci-dessous sont fournis en supposant que wallabag sera accessible à la racine d'un domaine `domain.tld` (ou d'un sous-domaine `wallabag.domain.tld`).
+> S'il est possible d'accéder à wallabag dans un sous-dossier (p.ex. `domain.tld/wallabag`), cette option n'est pas préconisée ni supportée par les développeurs.
+
 ## Configuration avec Apache
 
-N'oubliez pas d'activer le mod *rewrite* de Apache
-
-```bash
-a2enmod rewrite && systemctl reload apache2
-```
-
-En imaginant que vous vouliez installer wallabag dans le dossier
-`/var/www/wallabag` et que vous utilisiez PHP comme un module Apache,
-voici un vhost pour wallabag :
+### Apache et _mod-php_
 
 ```apache
 <VirtualHost *:80>
@@ -50,8 +52,12 @@ voici un vhost pour wallabag :
 </VirtualHost>
 ```
 
-Pour Apache 2.4, dans la section &lt;Directory /var/www/wallabag/web&gt;
-vous devez remplacer les directives suivantes :
+> **[info] _rewrite_**
+>
+> N'oubliez pas d'activer le mod *rewrite* d'Apache :
+> `a2enmod rewrite && systemctl reload apache2`
+
+Pour Apache 2.4, dans la section `<Directory /var/www/wallabag/web>`, vous devez remplacer les directives suivantes :
 
 ```apache
 AllowOverride None
@@ -65,10 +71,9 @@ par
 Require all granted
 ```
 
-Après que vous ayez rechargé/redémarré Apache, vous devriez pouvoir
-avoir accès à wallabag à l'adresse <http://domain.tld>.
+Après que vous ayez rechargé/redémarré Apache, vous devriez pouvoir avoir accès à wallabag à l'adresse <http://domain.tld>.
 
-### Utilisation de PHP-FPM au lieu de `mod_php`
+### Apache et PHP-FPM
 
 Si vous utilisez PHP-FPM (via `mod_proxy_fcgi` ou similaire), il faut indiquer à Apache de *conserver* l'en-tête `Authorization` dans les requêtes pour que l'API fonctionne. Dans les versions d'Apache `>= 2.4.13` ajoutez dans la section `<Directory /var/www/wallabag/web>` :
 
@@ -83,10 +88,6 @@ SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 ```
 
 ### Configuration avec Nginx
-
-En imaginant que vous vouliez installer wallabag dans le dossier
-`/var/www/wallabag`, voici un fichier de configuration Nginx pour
-wallabag :
 
 ```nginx
 server {
@@ -138,9 +139,7 @@ ajouter cette ligne dans votre configuration nginx
 
 ## Configuration avec lighttpd
 
-En imaginant que vous vouliez installer wallabag dans le dossier
-`/var/www/wallabag`, voici un fichier de configuration pour wallabag
-(éditez votre fichier `lighttpd.conf` collez-y cette configuration) :
+Éditez votre fichier `lighttpd.conf` collez-y cette configuration :
 
 ```lighttpd
 server.modules = (
@@ -177,11 +176,11 @@ url.rewrite-if-not-file = (
 
 ## Configuration avec Caddy
 
-En imaginant que vous vouliez installer wallabag dans le dossier
-`/var/www/wallabag`, voici un caddyfile pour wallabag
+
+Voici un caddyfile pour wallabag :
 
 ```caddy
-yourdomain.ru {
+domain.tld {
   root /var/www/wallabag/web
   fastcgi / /var/run/php7-fpm.sock php {
     index app.php
@@ -195,4 +194,4 @@ yourdomain.ru {
 }
 ```
 
-Vous pouvez aussi ajouter une directive `push` pour http/2 et aussi `gzip` pour compression. Le caddyfile est testé avec caddy v0.10.4
+Vous pouvez aussi ajouter une directive `push` pour http/2 et aussi `gzip` pour compression. Le caddyfile est testé avec caddy `v0.10.4`.


### PR DESCRIPTION
Small update for the Virtualhosts pages, in French and English.

1. "Factorization" of the location of installation at the top;
2. Warning about installing in subfolders instead of the root of a domain, to avoid too much tickets.