### PR TITLE
Use of hints plugin instead of alerts

### DIFF
--- a/book.json
+++ b/book.json
@@ -5,7 +5,7 @@
       "page-toc",
       "-sharing",
       "versions",
-      "alerts"
+      "hints"
     ],
     "pluginsConfig": {
         "edit-link": {

--- a/de/admin/installation/requirements.md
+++ b/de/admin/installation/requirements.md
@@ -2,9 +2,9 @@
 
 wallabag ist kompatibel mit **PHP &gt;= 5.6**, inkl. PHP 7.
 
-> **[info] Information**
->
-> To install wallabag easily, we create a `Makefile`, so you need to have the `make` tool.
+{% hint style="info" %}
+To install wallabag easily, we create a `Makefile`, so you need to have the `make` tool.
+{% endhint %}
 
 wallabag nutzt eine große Anzahl an Bibliotheken, um zu funktionieren.
 Diese Bibliotheken müssen mit einem Tool namens Composer installiert

--- a/de/admin/parameters.md
+++ b/de/admin/parameters.md
@@ -7,9 +7,10 @@ app/config/parameters.yml-Datei. Stelle sicher, dass sich deine mit
 dieser ähnelt. Wenn du nicht weißt, welchen Wert du setzen sollst,
 belasse es bei dem Standardwert.
 
-> **[danger] Information**
->
-> Um die Änderungen an der `parameters.yml` wirksam zu machen, musst du den Cache leeren, in dem du alles in `var/cache` mit diesem Kommando `bin/console cache:clear -e=prod` löschst.
+{% hint style="danger" %}
+Um die Änderungen an der `parameters.yml` wirksam zu machen, musst du den Cache leeren, in dem du alles in `var/cache` mit diesem Kommando `bin/console cache:clear -e=prod` löschst.
+{% endhint %}
+
 
 ```yaml
 parameters:

--- a/en/admin/installation/installation.md
+++ b/en/admin/installation/installation.md
@@ -12,22 +12,18 @@ cd wallabag && make install
 Now, read the following documentation to create your virtual host, then
 access your wallabag.
 
-> **[info] Information**
->
-> To define parameters with environment variables, you have to set these
-> variables with `SYMFONY__` prefix. For example,
-> `SYMFONY__DATABASE_DRIVER`. You can have a look at [Symfony
-> documentation](http://symfony.com/doc/current/cookbook/configuration/external_parameters.html).
+{% hint style="info" %}
+To define parameters with environment variables, you have to set these variables with `SYMFONY__` prefix, for example, `SYMFONY__DATABASE_DRIVER`.
+You can have a look at [Symfony documentation](http://symfony.com/doc/current/cookbook/configuration/external_parameters.html).
+{% endhint %}
 
----
+{% hint style="tip" %}
+If you want to use SQLite to store your data, please put `%kernel.root_dir%/../data/db/wallabag.sqlite` for the `database_path` parameter during installation.
+{% endhint %}
 
-> **[info] Information**
->
-> If you want to use SQLite to store your data, please put `%kernel.root_dir%/../data/db/wallabag.sqlite` for the `database_path` parameter during installation.
-
-> **[info] Information**
->
-> If you're installing Wallabag behind Squid as a reverse proxy, make sure to update your squid.conf configuration to include "login=PASS" in the "cache_peer" line. This is necessary for API calls to work properly.
+{% hint style="info" %}
+If you're installing Wallabag behind Squid as a reverse proxy, make sure to update your `squid.conf` configuration to include `login=PASS` in the `cache_peer` line. This is necessary for API calls to work properly.
+{% endhint %}
 
 ## On shared hosting
 

--- a/en/admin/installation/requirements.md
+++ b/en/admin/installation/requirements.md
@@ -2,9 +2,9 @@
 
 wallabag is compatible with **PHP >= 5.6**, including PHP 7.1.
 
-> **[info] Information**
->
-> To install wallabag easily, we provide a `Makefile`, so you need to have the `make` tool.
+{% hint style="info" %}
+To install wallabag easily, we provide a `Makefile`, so you need to have the `make` tool.
+{% endhint %}
 
 wallabag uses a large number of PHP libraries in order to function.
 These libraries must be installed with a tool called Composer. You need

--- a/en/admin/installation/virtualhosts.md
+++ b/en/admin/installation/virtualhosts.md
@@ -1,14 +1,13 @@
 # Virtual hosts
 
-> **[info] Setup directory**
->
-> We assume that wallabag was installed in the `/var/www/wallabag` folder.
+{% hint style="tip" %}
+We assume that wallabag was installed in the `/var/www/wallabag` folder.
+{% endhint %}
 
-
-> **[warning] Warning**
->
-> The following configurations are given as examples, assuming that wallabag will be directly accessed at the root of `domain.tld` (or a `wallabag.domain.tld` subdomain).
-> Installation in folders can work, but is not supported by the maintainers.
+{% hint style="danger" %}
+The following configurations are given as examples, assuming that wallabag will be directly accessed at the root of `domain.tld` (or a `wallabag.domain.tld` subdomain).
+Installation in folders can work, but is not supported by the maintainers.
+{% endhint %}
 
 ## Configuration on Apache
 
@@ -52,11 +51,10 @@
 </VirtualHost>
 ```
 
-> **[warning]** _Rewrite_ mod
->
-> Do not forget to activate the *rewrite* mod of Apache:
-> `a2enmod rewrite && systemctl reload apache2`
-
+{% hint style="danger" %}
+Do not forget to activate the *rewrite* mod of Apache:
+`a2enmod rewrite && systemctl reload apache2`
+{% endhint %}
 
 Note for Apache 2.4, in the section `<Directory /var/www/wallabag/web>`, you have to replace the directives:
 

--- a/en/admin/parameters.md
+++ b/en/admin/parameters.md
@@ -6,9 +6,9 @@ Here is the last version of the default app/config/parameters.yml file.
 Be sure that yours respects this one. If you don't know which value you
 need to set, please leave the default one.
 
-> **[danger] Information**
->
-> To apply changes to `parameters.yml`, you have to clear your cache by deleting everything in `var/cache` with this command: `bin/console cache:clear -e=prod`.
+{% hint style="tip" %}
+To apply changes to `parameters.yml`, you have to clear your cache by deleting everything in `var/cache` with this command: `bin/console cache:clear -e=prod`.
+{% endhint %}
 
 ```yaml
 parameters:

--- a/en/developer/paywall.md
+++ b/en/developer/paywall.md
@@ -1,8 +1,9 @@
 # Configuring paywall access
 
-> **[warning] Important**
->
-> This is the technical part about the paywall. If you are looking for the user part, please check [that page instead](../user/articles/restricted.md).
+
+{% hint style="working" %}
+This is the technical part about the paywall. If you are looking for the user part, please check [that page instead](../user/articles/restricted.md).
+{% endhint %}
 
 Read [this part of the documentation](../user/errors_during_fetching.md)
 to understand the configuration files, which are located under `vendor/j0k3r/graby-site-config/`. For most of the websites, this file

--- a/en/user/articles/restricted.md
+++ b/en/user/articles/restricted.md
@@ -30,9 +30,9 @@ Once enable, you'll see a new item in the left menu: **Site Credentials**.
 
 Click on it to go to the management of your site credentials. You'll be able to add many login / password.
 
-> **[info] Information**
->
-> These information will only be accessible by **YOU** and no other users on the wallabag instance.
+{% hint style="info" %}
+These information will only be accessible by **YOU** and no other users on the wallabag instance.
+{% endhint %}
 
 ## Security
 

--- a/fr/admin/installation/requirements.md
+++ b/fr/admin/installation/requirements.md
@@ -2,9 +2,10 @@
 
 wallabag est compatible avec **PHP &gt;= 5.6**, PHP 7 inclus.
 
-> **[info] Information**
->
-> Pour installer wallabag facilement, nous avons créé un `Makefile`, vous avez donc besoin d'avoir installé l'outil `make`.
+{% hint style="info" %}
+Pour installer wallabag facilement, nous avons créé un `Makefile`, vous avez donc besoin d'avoir installé l'outil `make`.
+{% endhint %}
+
 
 wallabag utilise un grand nombre de bibliothèques PHP pour fonctionner.
 Ces bibliothèques doivent être installées à l'aide d'un outil nommé

--- a/fr/admin/installation/virtualhosts.md
+++ b/fr/admin/installation/virtualhosts.md
@@ -1,14 +1,14 @@
 # Virtual hosts
 
-> **[info] Répertoire d'installation**
->
-> Nous supposons que wallabag a été installé dans le répertoire `/var/www/wallabag`.
+{% hint style="tip" %}
+Nous supposons que wallabag a été installé dans le répertoire `/var/www/wallabag`.
+{% endhint %}
 
 
-> **[warn] Avertissement**
->
-> Les exemples de configuration ci-dessous sont fournis en supposant que wallabag sera accessible à la racine d'un domaine `domain.tld` (ou d'un sous-domaine `wallabag.domain.tld`).
-> S'il est possible d'accéder à wallabag dans un sous-dossier (p.ex. `domain.tld/wallabag`), cette option n'est pas préconisée ni supportée par les développeurs.
+{% hint style="danger" %}
+Les exemples de configuration ci-dessous sont fournis en supposant que wallabag sera accessible à la racine d'un domaine `domain.tld` (ou d'un sous-domaine `wallabag.domain.tld`).
+S'il est possible d'accéder à wallabag dans un sous-dossier (p.ex. `domain.tld/wallabag`), cette option n'est pas préconisée ni supportée par les développeurs.
+{% endhint %}
 
 ## Configuration avec Apache
 
@@ -52,10 +52,10 @@
 </VirtualHost>
 ```
 
-> **[info] _rewrite_**
->
-> N'oubliez pas d'activer le mod *rewrite* d'Apache :
-> `a2enmod rewrite && systemctl reload apache2`
+{% hint style="info" %}
+N'oubliez pas d'activer le mod *rewrite* d'Apache :
+`a2enmod rewrite && systemctl reload apache2`
+{% endhint %}
 
 Pour Apache 2.4, dans la section `<Directory /var/www/wallabag/web>`, vous devez remplacer les directives suivantes :
 

--- a/fr/admin/parameters.md
+++ b/fr/admin/parameters.md
@@ -7,9 +7,9 @@ app/config/parameters.yml. Soyez sur que le votre respecte celui-ci. Si
 vous ne savez pas quelle valeur vous devez mettre, laissez celle par
 défaut.
 
-> **[danger] Information**
->
-> Pour appliquer les changements dans `parameters.yml`, vous devez vider le cache en supprimant tout ce qui se trouve dans `var/cache` avec cette commande : `bin/console cache:clear -e=prod`.
+{% hint style="tip" %}
+Pour appliquer les changements dans `parameters.yml`, vous devez vider le cache en supprimant tout ce qui se trouve dans `var/cache` avec cette commande : `bin/console cache:clear -e=prod`.
+{% endhint %}
 
 ```yml
 parameters:

--- a/fr/developer/paywall.md
+++ b/fr/developer/paywall.md
@@ -1,8 +1,8 @@
 # Configurer l'accès à un paywall
 
-> **[warning] Important**
->
-> C'est la partie technique à propos du paywall. Si vous cherchez la partie utilisateur, allez plutôt [voir cette page](../user/articles/restricted.md).
+{% hint style="working" %}
+C'est la partie technique à propos du paywall. Si vous cherchez la partie utilisateur, allez plutôt [voir cette page](../user/articles/restricted.md).
+{% endhint %}
 
 
 Lisez [cette documentation](../user/errors_during_fetching.md)

--- a/fr/user/articles/restricted.md
+++ b/fr/user/articles/restricted.md
@@ -31,9 +31,9 @@ Une fois activée, vous verrez une nouvelle entrée dans le menu de gauche: **Ac
 
 Cliquez sur le lien pour aller à la gestion de vos accès aux sites. Vous pourrez ajouter autant de login / mot de passe que vous le souhaitez.
 
-> **[info] Information**
->
-> Ces informations sont accessible uniquement par **VOUS** et aucun autre utilisateur de l'instance wallabag.
+{% hint style="info" %}
+Ces informations sont accessible uniquement par **VOUS** et aucun autre utilisateur de l'instance wallabag.
+{% endhint %}
 
 ## Sécurité
 

--- a/it/admin/installation/requirements.md
+++ b/it/admin/installation/requirements.md
@@ -3,9 +3,9 @@ Requisiti
 
 wallabag è compatibile con PHP &gt;= 5.6, incluso PHP 7.
 
-> **[info] Informazione**
->
-> Per installare wallabag facilmente, noi offriamo un `Makefile`, quindi dovrete avere lo strumento `make`.
+{% hint style="info" %}
+Per installare wallabag facilmente, noi offriamo un `Makefile`, quindi dovrete avere lo strumento `make`.
+{% endhint %}
 
 wallabag utilizza un gran numero di librerie PHP per funzionare. Queste
 librerie vanno installate tramite uno strumento chiamato Composer.

--- a/it/admin/parameters.md
+++ b/it/admin/parameters.md
@@ -6,10 +6,9 @@ Ecco l'ultima versione del file app/config/parameters.yml di default.
 Assicuratevi che la vostra rispetti questa. Se non sapete quale
 parametro dovete impostare, si prega di lasciare quello di default.
 
-> **[pericolo] Informazione**
->
-> Per applicare i cambiamenti a `parameters.yml`, dovete pulire la cache eliminando tutti i contenuti della cartella `var/cache` con questo comando: `bin/console cache:clear -e=prod`.
-
+{% hint style="tip" %}
+Per applicare i cambiamenti a `parameters.yml`, dovete pulire la cache eliminando tutti i contenuti della cartella `var/cache` con questo comando: `bin/console cache:clear -e=prod`.
+{% endhint %}
 
 ```yaml
 parameters:

--- a/it/developer/paywall.md
+++ b/it/developer/paywall.md
@@ -1,8 +1,8 @@
 # Configurare l'accesso al paywall
 
-> **[attenzione] Importante**
->
-> Questa è la parte tecnica a proposito del paywall. Se state cercando la sezione dedicata all'utente, si prega di leggere [questa pagina](../user/articles/restricted.md).
+{% hint style="working" %}
+Questa è la parte tecnica a proposito del paywall. Se state cercando la sezione dedicata all'utente, si prega di leggere [questa pagina](../user/articles/restricted.md).
+{% endhint %}
 
 Leggete [questa parte della documentazione](../user/errors_during_fetching.md)
 per capire i file di configurazione, i quali si trovano sotto `vendor/j0k3r/graby-site-config/`. Per la maggior parte dei siti, questo file è già configurato: le istruzioni seguenti sono valide solo per i siti web che non sono ancora configurati.


### PR DESCRIPTION
The plugin alerts shows issues with following blocks.
Using hints instead, even if also not updated, allows for a cleaner result.

![image](https://user-images.githubusercontent.com/1850197/49972793-08272c00-ff33-11e8-9a68-e697bf8f2688.png)

![image](https://user-images.githubusercontent.com/1850197/49972802-107f6700-ff33-11e8-8352-baac549341fb.png)
