### PR TITLE
Add warning for DE & IT translations

### DIFF
--- a/de/README.md
+++ b/de/README.md
@@ -2,7 +2,7 @@ wallabag Dokumentation
 ======================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ![wallabag Logo](../img/wallabag.png)

--- a/de/README.md
+++ b/de/README.md
@@ -1,6 +1,10 @@
 wallabag Dokumentation
 ======================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ![wallabag Logo](../img/wallabag.png)
 
 **wallabag** ist eine Read-it-later Applikation: Sie speichert Websites,

--- a/de/SUMMARY.md
+++ b/de/SUMMARY.md
@@ -1,5 +1,9 @@
 # Zusammenfassung
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 * [Startseite](README.md)
 
 ## Nutzer

--- a/de/SUMMARY.md
+++ b/de/SUMMARY.md
@@ -1,7 +1,7 @@
 # Zusammenfassung
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 * [Startseite](README.md)

--- a/de/admin/asynchronous.md
+++ b/de/admin/asynchronous.md
@@ -2,7 +2,7 @@ Asynchrone Aufgaben
 ===================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Um große asynchrone Aufgaben zu starten (etwa für große Importe), können

--- a/de/admin/asynchronous.md
+++ b/de/admin/asynchronous.md
@@ -1,6 +1,10 @@
 Asynchrone Aufgaben
 ===================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Um große asynchrone Aufgaben zu starten (etwa für große Importe), können
 wir RabbitMQ oder Redis nutzen.
 

--- a/de/admin/backup.md
+++ b/de/admin/backup.md
@@ -2,7 +2,7 @@ wallabag sichern
 ================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Da es manchmal vorkommen kann, dass dir ein Fehler mit deiner wallabag

--- a/de/admin/backup.md
+++ b/de/admin/backup.md
@@ -1,6 +1,10 @@
 wallabag sichern
 ================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Da es manchmal vorkommen kann, dass dir ein Fehler mit deiner wallabag
 unterläuft und du Daten verlierst oder deine wallabag auf einen anderen
 Server verschieben willst, ist eine Sicherung der Daten sicher ratsam.

--- a/de/admin/console_commands.md
+++ b/de/admin/console_commands.md
@@ -1,6 +1,10 @@
 Kommandozeilenbefehle
 =====================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 wallabag hat ein paar Kommandos, um einige Aufgaben zu managen. Du kannst
 alle Kommandos auflisten, in dem du `bin/console` in dem wallabag Ordner
 ausführst.

--- a/de/admin/console_commands.md
+++ b/de/admin/console_commands.md
@@ -2,7 +2,7 @@ Kommandozeilenbefehle
 =====================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag hat ein paar Kommandos, um einige Aufgaben zu managen. Du kannst

--- a/de/admin/installation/README.md
+++ b/de/admin/installation/README.md
@@ -2,5 +2,5 @@ Installation von wallabag
 =========================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}

--- a/de/admin/installation/README.md
+++ b/de/admin/installation/README.md
@@ -1,2 +1,6 @@
 Installation von wallabag
 =========================
+
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}

--- a/de/admin/installation/installation.md
+++ b/de/admin/installation/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Auf einem dedizierten Webserver (empfohlener Weg)

--- a/de/admin/installation/installation.md
+++ b/de/admin/installation/installation.md
@@ -1,5 +1,9 @@
 # Installation
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Auf einem dedizierten Webserver (empfohlener Weg)
 
 Um wallabag selbst zu installieren, musst du die folgenden Kommandos

--- a/de/admin/installation/requirements.md
+++ b/de/admin/installation/requirements.md
@@ -1,7 +1,7 @@
 # Voraussetzungen
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag ist kompatibel mit **PHP &gt;= 7.2**.

--- a/de/admin/installation/requirements.md
+++ b/de/admin/installation/requirements.md
@@ -1,5 +1,9 @@
 # Voraussetzungen
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 wallabag ist kompatibel mit **PHP &gt;= 7.2**.
 
 {% hint style="info" %}

--- a/de/admin/installation/rightaccess.md
+++ b/de/admin/installation/rightaccess.md
@@ -1,5 +1,9 @@
 # Rechte, um das Projektverzeichnis zu betreten
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Testumgebung
 
 Wenn wir nur wallabag testen wollen, führen wir nur das Kommando

--- a/de/admin/installation/rightaccess.md
+++ b/de/admin/installation/rightaccess.md
@@ -1,7 +1,7 @@
 # Rechte, um das Projektverzeichnis zu betreten
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Testumgebung

--- a/de/admin/installation/virtualhosts.md
+++ b/de/admin/installation/virtualhosts.md
@@ -1,7 +1,7 @@
 # Virtualhosts
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Konfiguration von Apache

--- a/de/admin/installation/virtualhosts.md
+++ b/de/admin/installation/virtualhosts.md
@@ -1,5 +1,9 @@
 # Virtualhosts
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Konfiguration von Apache
 
 Vergiss nicht, die *rewrite* mod von Apache zu aktivieren.

--- a/de/admin/internal_settings.md
+++ b/de/admin/internal_settings.md
@@ -1,5 +1,9 @@
 # Wozu sind die internen Einstellungen?
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Die Seite interne Einstellungen ist nur für den Administrator der Instanz verfügbar. Sie erlaubt die Verwaltungen von weiteren Einstellungen, wie z.B. die Aktivierung einiger Featuers.
 
 ## Analytiken

--- a/de/admin/internal_settings.md
+++ b/de/admin/internal_settings.md
@@ -1,7 +1,7 @@
 # Wozu sind die internen Einstellungen?
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Die Seite interne Einstellungen ist nur für den Administrator der Instanz verfügbar. Sie erlaubt die Verwaltungen von weiteren Einstellungen, wie z.B. die Aktivierung einiger Featuers.

--- a/de/admin/parameters.md
+++ b/de/admin/parameters.md
@@ -1,5 +1,9 @@
 # Was bedeuten die Parameter?
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Standardeinstellungen der parameters.yml
 
 Dies ist die letzte standardisierte Version der

--- a/de/admin/parameters.md
+++ b/de/admin/parameters.md
@@ -1,7 +1,7 @@
 # Was bedeuten die Parameter?
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Standardeinstellungen der parameters.yml

--- a/de/admin/query-upgrade-21-22.md
+++ b/de/admin/query-upgrade-21-22.md
@@ -2,7 +2,7 @@ Migration 20161001072726
 ========================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 MySQL

--- a/de/admin/query-upgrade-21-22.md
+++ b/de/admin/query-upgrade-21-22.md
@@ -1,6 +1,10 @@
 Migration 20161001072726
 ========================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 MySQL
 -----
 

--- a/de/admin/upgrade.md
+++ b/de/admin/upgrade.md
@@ -2,7 +2,7 @@ wallabag-Installation aktualisieren
 ===================================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Du wirst hier mehrere Wege finden, um deine wallabag zu aktualisieren:

--- a/de/admin/upgrade.md
+++ b/de/admin/upgrade.md
@@ -1,6 +1,10 @@
 wallabag-Installation aktualisieren
 ===================================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Du wirst hier mehrere Wege finden, um deine wallabag zu aktualisieren:
 
 -   [von 2.1.x zu 2.2.x](#upgrade-von-2-1-x-zu-2-2-x)

--- a/de/apps/android.md
+++ b/de/apps/android.md
@@ -1,6 +1,10 @@
 Android App
 ===========
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Zweck dieses Dokuments
 ----------------------
 

--- a/de/apps/android.md
+++ b/de/apps/android.md
@@ -2,7 +2,7 @@ Android App
 ===========
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Zweck dieses Dokuments

--- a/de/developer/api/README.md
+++ b/de/developer/api/README.md
@@ -1,6 +1,10 @@
 API Dokumentation
 =================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Dank dieser Dokumentation werden wir sehen, wie wir mit der wallabag API
 interagieren.
 

--- a/de/developer/api/README.md
+++ b/de/developer/api/README.md
@@ -2,7 +2,7 @@ API Dokumentation
 =================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Dank dieser Dokumentation werden wir sehen, wie wir mit der wallabag API

--- a/de/developer/api/methods.md
+++ b/de/developer/api/methods.md
@@ -2,7 +2,7 @@ Deinen ersten Eintrag hinzufügen
 --------------------------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Dokumentation für diese Methode:

--- a/de/developer/api/methods.md
+++ b/de/developer/api/methods.md
@@ -1,6 +1,10 @@
 Deinen ersten Eintrag hinzufügen
 --------------------------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Dokumentation für diese Methode:
 https://app.wallabag.it/api/doc#post--api-entries.{_format}
 

--- a/de/developer/api/oauth.md
+++ b/de/developer/api/oauth.md
@@ -2,7 +2,7 @@ Einen neuen API Client erstellen
 --------------------------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 In deinem wallabag Account, kannst du einen neuen API Client unter

--- a/de/developer/api/oauth.md
+++ b/de/developer/api/oauth.md
@@ -1,6 +1,10 @@
 Einen neuen API Client erstellen
 --------------------------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 In deinem wallabag Account, kannst du einen neuen API Client unter
 dieser URL https://app.wallabag.it/developer/client/create erstellen.
 

--- a/de/developer/api/resources.md
+++ b/de/developer/api/resources.md
@@ -1,6 +1,10 @@
 Drittanbieter Ressourcen
 ------------------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Einige Applikationen oder Bibliotheken nutzen unsere API. Hier ist eine
 nicht abschließende Aufzählung von ihnen:
 

--- a/de/developer/api/resources.md
+++ b/de/developer/api/resources.md
@@ -2,7 +2,7 @@ Drittanbieter Ressourcen
 ------------------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Einige Applikationen oder Bibliotheken nutzen unsere API. Hier ist eine

--- a/de/developer/docker.md
+++ b/de/developer/docker.md
@@ -1,6 +1,10 @@
 Lasse wallabag in docker-compose laufen
 =======================================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Um deine eigene Entwicklungsinstanz von wallabag laufen zu lassen,
 möchtest du vielleicht die vorkonfigurierten docker compose Dateien
 nutzen.

--- a/de/developer/docker.md
+++ b/de/developer/docker.md
@@ -2,7 +2,7 @@ Lasse wallabag in docker-compose laufen
 =======================================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Um deine eigene Entwicklungsinstanz von wallabag laufen zu lassen,

--- a/de/developer/documentation.md
+++ b/de/developer/documentation.md
@@ -1,6 +1,10 @@
 Wirke an dieser Dokumentation mit
 =================================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Quellen der Dokumentation sind hier zu finden
 https://github.com/wallabag/doc/
 

--- a/de/developer/documentation.md
+++ b/de/developer/documentation.md
@@ -2,7 +2,7 @@ Wirke an dieser Dokumentation mit
 =================================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Quellen der Dokumentation sind hier zu finden

--- a/de/developer/front_end.md
+++ b/de/developer/front_end.md
@@ -1,7 +1,7 @@
 # Tipps für Front-End Entwickler
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Mit der Version 2.3 nutzt wallabag webpack, um seine Assets zu packen.
@@ -35,7 +35,7 @@ Wenn du deine Änderungen nutzen willst, baue sie in der
 Produktionsumgebung durch das Ausführen von `yarn run build:prod`.
 Dies wird alle Assets für wallabag erstellen. Um zu testen, dass
 alles ordentlich funktioniert, wirst du einen im Produktionsmodus
-laufenden Server bruachen, z.B. mit 
+laufenden Server bruachen, z.B. mit
 `bin/console server:run -e=prod`.
 
 Vergiss nicht, die Produktions-Builds zu erstellen bevor du sie

--- a/de/developer/front_end.md
+++ b/de/developer/front_end.md
@@ -1,5 +1,9 @@
 # Tipps für Front-End Entwickler
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Mit der Version 2.3 nutzt wallabag webpack, um seine Assets zu packen.
 
 ## Entwicklermodus

--- a/de/developer/paywall.md
+++ b/de/developer/paywall.md
@@ -1,6 +1,10 @@
 Artikel hinter einer Paywall
 ============================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 wallabag kann auch Artikel von Webseiten auslesen, welche eine Paywall (dt. Bezahlschranke) verwenden.
 
 Paywall-Authentifizierung aktivieren

--- a/de/developer/paywall.md
+++ b/de/developer/paywall.md
@@ -2,7 +2,7 @@ Artikel hinter einer Paywall
 ============================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag kann auch Artikel von Webseiten auslesen, welche eine Paywall (dt. Bezahlschranke) verwenden.

--- a/de/developer/testsuite.md
+++ b/de/developer/testsuite.md
@@ -1,6 +1,10 @@
 Tests
 =====
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Um die Entwicklungsqualität von wallabag sicherzustellen,
 haben wir Tests mit [PHPUnit](https://phpunit.de) geschrieben.
 

--- a/de/developer/testsuite.md
+++ b/de/developer/testsuite.md
@@ -2,7 +2,7 @@ Tests
 =====
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Um die Entwicklungsqualität von wallabag sicherzustellen,

--- a/de/developer/translate.md
+++ b/de/developer/translate.md
@@ -2,7 +2,7 @@
 ==================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag Webapplikation

--- a/de/developer/translate.md
+++ b/de/developer/translate.md
@@ -1,6 +1,10 @@
 Übersetze wallabag
 ==================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 wallabag Webapplikation
 -----------------------
 

--- a/de/user/articles/README.md
+++ b/de/user/articles/README.md
@@ -1,7 +1,7 @@
 # Artikel
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Artikel sind das Kern-Feature von wallabag. Der Inhalt-Parser von wallabag, Graby genannt, sucht sich aus Artikeln den Inhalt und zwar nur den Inhalt.

--- a/de/user/articles/README.md
+++ b/de/user/articles/README.md
@@ -1,5 +1,9 @@
 # Artikel
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Artikel sind das Kern-Feature von wallabag. Der Inhalt-Parser von wallabag, Graby genannt, sucht sich aus Artikeln den Inhalt und zwar nur den Inhalt.
 
 ## Artikel als gelesen markieren

--- a/de/user/articles/annotations.md
+++ b/de/user/articles/annotations.md
@@ -1,6 +1,10 @@
 Artikel-Anmerkungen
 -------------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 In jedem Artikel, den du liest, kannst du Anmerkungen hinzufügen. Es ist
 einfacher mit ein paar Bilder erklärt.
 

--- a/de/user/articles/annotations.md
+++ b/de/user/articles/annotations.md
@@ -2,7 +2,7 @@ Artikel-Anmerkungen
 -------------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 In jedem Artikel, den du liest, kannst du Anmerkungen hinzufügen. Es ist

--- a/de/user/articles/download.md
+++ b/de/user/articles/download.md
@@ -2,7 +2,7 @@ Artikel herunterladen
 ---------------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Du kannst jeden Artikel in verschiedenen Formaten herunterladen: ePUB,

--- a/de/user/articles/download.md
+++ b/de/user/articles/download.md
@@ -1,6 +1,10 @@
 Artikel herunterladen
 ---------------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Du kannst jeden Artikel in verschiedenen Formaten herunterladen: ePUB,
 MOBI, PDF, XML, JSON, CSV.
 

--- a/de/user/articles/restricted.md
+++ b/de/user/articles/restricted.md
@@ -1,5 +1,9 @@
 # Restriktierte Artikel
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 wallabag hat ein System, um Artikel hinter einer Paywall zu verarbeiten, indem die Login-Daten zur Verfügung gestellt werden,
 wenn der Artikel geladen wird.
 

--- a/de/user/articles/restricted.md
+++ b/de/user/articles/restricted.md
@@ -1,7 +1,7 @@
 # Restriktierte Artikel
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag hat ein System, um Artikel hinter einer Paywall zu verarbeiten, indem die Login-Daten zur Verfügung gestellt werden,

--- a/de/user/articles/save.md
+++ b/de/user/articles/save.md
@@ -1,6 +1,10 @@
 Speichere deinen ersten Artikel
 -------------------------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Die Hauptzweck von wallabag ist es, Artikel aus dem Web zu speichern. Es
 gibt viele Wege, dieses Ziel zu erreichen. Wenn du denkst, dass ein
 Artikel falsch angezeigt wird, kannst du [diese Dokumentation lesen](../errors_during_fetching.md).

--- a/de/user/articles/save.md
+++ b/de/user/articles/save.md
@@ -2,7 +2,7 @@ Speichere deinen ersten Artikel
 -------------------------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Die Hauptzweck von wallabag ist es, Artikel aus dem Web zu speichern. Es

--- a/de/user/articles/share.md
+++ b/de/user/articles/share.md
@@ -1,6 +1,10 @@
 Artikel teilen
 --------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Wenn du einen Artikel liest, kannst du ihn auch teilen. Klicke dazu
 einfach auf den Teilen-Button:
 

--- a/de/user/articles/share.md
+++ b/de/user/articles/share.md
@@ -2,7 +2,7 @@ Artikel teilen
 --------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Wenn du einen Artikel liest, kannst du ihn auch teilen. Klicke dazu

--- a/de/user/configuration/README.md
+++ b/de/user/configuration/README.md
@@ -2,7 +2,7 @@ Konfiguration
 =============
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Nun, da du eingeloggt bist, ist es Zeit, deinen Account so zu

--- a/de/user/configuration/README.md
+++ b/de/user/configuration/README.md
@@ -1,6 +1,10 @@
 Konfiguration
 =============
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Nun, da du eingeloggt bist, ist es Zeit, deinen Account so zu
 konfigurieren, wie du möchtest.
 

--- a/de/user/configuration/password.md
+++ b/de/user/configuration/password.md
@@ -1,4 +1,8 @@
 Passwort
 --------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Du kannst dein Passwort hier ändern (8 Zeichen Minimum).

--- a/de/user/configuration/password.md
+++ b/de/user/configuration/password.md
@@ -2,7 +2,7 @@ Passwort
 --------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Du kannst dein Passwort hier ändern (8 Zeichen Minimum).

--- a/de/user/configuration/rss.md
+++ b/de/user/configuration/rss.md
@@ -1,7 +1,7 @@
 # RSS
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag stellt RSS Feeds für jeden Artikelstatus bereit: ungelesen,

--- a/de/user/configuration/rss.md
+++ b/de/user/configuration/rss.md
@@ -1,5 +1,9 @@
 # RSS
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 wallabag stellt RSS Feeds für jeden Artikelstatus bereit: ungelesen,
 Favoriten und Archiv.
 

--- a/de/user/configuration/settings.md
+++ b/de/user/configuration/settings.md
@@ -2,7 +2,7 @@ Einstellungen
 -------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ### Theme

--- a/de/user/configuration/settings.md
+++ b/de/user/configuration/settings.md
@@ -1,6 +1,10 @@
 Einstellungen
 -------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ### Theme
 
 wallabag ist anpassbar. Du kannst dein bevorzugtes Theme hier auswählen.

--- a/de/user/configuration/tagging_rules.md
+++ b/de/user/configuration/tagging_rules.md
@@ -1,6 +1,10 @@
 Tagging-Regeln
 --------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Wenn du automatisch einen Tag zu einem neuen Artikel zuweisen lassen
 möchtest, ist dieser Teil der Konfiguration, was du suchst.
 

--- a/de/user/configuration/tagging_rules.md
+++ b/de/user/configuration/tagging_rules.md
@@ -2,7 +2,7 @@ Tagging-Regeln
 --------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Wenn du automatisch einen Tag zu einem neuen Artikel zuweisen lassen
@@ -34,7 +34,7 @@ Tagging-Regeln zu erstellen (sei vorsichtig, denn bei einigen Werten
 musst du Anführungszeichen hinzufügen, z.B. `language = "de"`):
 
 
-  Variable      | Bedeutung                                          
+  Variable      | Bedeutung
   ------------- | -------------------
   title         | Titel des Artikels
   url           | URL des Artikels

--- a/de/user/configuration/user_information.md
+++ b/de/user/configuration/user_information.md
@@ -1,6 +1,10 @@
 Benutzer-Informationen
 ----------------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Du kannst deinen Namen ändern, deine E-Mail-Adresse und die
 Zwei-Faktor-Authentifizierung aktivieren.
 

--- a/de/user/configuration/user_information.md
+++ b/de/user/configuration/user_information.md
@@ -2,7 +2,7 @@ Benutzer-Informationen
 ----------------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Du kannst deinen Namen ändern, deine E-Mail-Adresse und die

--- a/de/user/configuring_mobile.md
+++ b/de/user/configuring_mobile.md
@@ -1,6 +1,10 @@
 Konfiguration mobiler Apps für wallabag
 =======================================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Schritte zum Konfigurieren der App
 ----------------------------------
 

--- a/de/user/configuring_mobile.md
+++ b/de/user/configuring_mobile.md
@@ -2,7 +2,7 @@ Konfiguration mobiler Apps für wallabag
 =======================================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Schritte zum Konfigurieren der App

--- a/de/user/create_account.md
+++ b/de/user/create_account.md
@@ -1,6 +1,10 @@
 Account erstellen
 =================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Registrierungsformular
 ----------------------
 

--- a/de/user/create_account.md
+++ b/de/user/create_account.md
@@ -2,7 +2,7 @@ Account erstellen
 =================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Registrierungsformular

--- a/de/user/errors_during_fetching.md
+++ b/de/user/errors_during_fetching.md
@@ -1,7 +1,7 @@
 # Fehler während des Artikelladens
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Warum schlägt das Laden eines Artikels fehl?

--- a/de/user/errors_during_fetching.md
+++ b/de/user/errors_during_fetching.md
@@ -1,5 +1,9 @@
 # Fehler während des Artikelladens
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Warum schlägt das Laden eines Artikels fehl?
 
 Das kann verschiedene Ursachen haben:

--- a/de/user/faq.md
+++ b/de/user/faq.md
@@ -1,6 +1,10 @@
 Häufig gestellte Fragen
 =======================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Während der Installation sehe ich den Fehler `Error Output: sh: 1: @post-cmd: not found`
 ----------------------------------------------------------------------------------------
 

--- a/de/user/faq.md
+++ b/de/user/faq.md
@@ -2,7 +2,7 @@ Häufig gestellte Fragen
 =======================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Während der Installation sehe ich den Fehler `Error Output: sh: 1: @post-cmd: not found`

--- a/de/user/filters.md
+++ b/de/user/filters.md
@@ -1,6 +1,10 @@
 Filter
 ======
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Um Artikel leichter zu erreichen, kannst du sie filtern. Klicke auf das
 dritte Symbol in der oberen Leiste.
 

--- a/de/user/filters.md
+++ b/de/user/filters.md
@@ -2,7 +2,7 @@ Filter
 ======
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Um Artikel leichter zu erreichen, kannst du sie filtern. Klicke auf das

--- a/de/user/import/Instapaper.md
+++ b/de/user/import/Instapaper.md
@@ -1,7 +1,7 @@
 # Von Instapaper
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Exportiere deine Instapaper Daten

--- a/de/user/import/Instapaper.md
+++ b/de/user/import/Instapaper.md
@@ -1,5 +1,9 @@
 # Von Instapaper
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Exportiere deine Instapaper Daten
 
 Auf der Seite Einstellungen

--- a/de/user/import/Pinboard.md
+++ b/de/user/import/Pinboard.md
@@ -1,7 +1,7 @@
 # Von Pinboard
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Exportiere deine Pinboard Daten

--- a/de/user/import/Pinboard.md
+++ b/de/user/import/Pinboard.md
@@ -1,5 +1,9 @@
 # Von Pinboard
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Exportiere deine Pinboard Daten
 
 Auf der Seite Backup

--- a/de/user/import/Pocket.md
+++ b/de/user/import/Pocket.md
@@ -1,5 +1,9 @@
 # Pocket
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Erstelle eine neue Applikation in Pocket
 
 Um deine Daten von Pocket zu importieren, nutzen wir die Pocket API. Du

--- a/de/user/import/Pocket.md
+++ b/de/user/import/Pocket.md
@@ -1,7 +1,7 @@
 # Pocket
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Erstelle eine neue Applikation in Pocket

--- a/de/user/import/README.md
+++ b/de/user/import/README.md
@@ -2,7 +2,7 @@ Migration von einem Drittanbieter
 =================================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 In wallabag 2.x kannst du Daten von folgenden Anbietern importieren:

--- a/de/user/import/README.md
+++ b/de/user/import/README.md
@@ -1,6 +1,10 @@
 Migration von einem Drittanbieter
 =================================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 In wallabag 2.x kannst du Daten von folgenden Anbietern importieren:
 
 -   [Pocket](Pocket.md)

--- a/de/user/import/Readability.md
+++ b/de/user/import/Readability.md
@@ -1,5 +1,9 @@
 # Von Readability
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Exportiere deine Readability Daten
 
 Auf der Seite Tools

--- a/de/user/import/Readability.md
+++ b/de/user/import/Readability.md
@@ -1,7 +1,7 @@
 # Von Readability
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Exportiere deine Readability Daten

--- a/de/user/import/wallabagv1.md
+++ b/de/user/import/wallabagv1.md
@@ -1,5 +1,9 @@
 # wallabag 1.x
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Wenn du in der Vergangenheit wallabag 1.x genutzt hast, musst du deine
 Daten exportieren, bevor du auf wallabag 2.x umsteigst, da sich viel an
 der Anwendung und der Datenbank geändert hast. In deiner alten

--- a/de/user/import/wallabagv1.md
+++ b/de/user/import/wallabagv1.md
@@ -1,7 +1,7 @@
 # wallabag 1.x
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Wenn du in der Vergangenheit wallabag 1.x genutzt hast, musst du deine

--- a/de/user/import/wallabagv2.md
+++ b/de/user/import/wallabagv2.md
@@ -1,7 +1,7 @@
 # wallabag 2.x
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Gehe auf der alten wallabag-Instanz, die du vorher genutzt hast, auf

--- a/de/user/import/wallabagv2.md
+++ b/de/user/import/wallabagv2.md
@@ -1,5 +1,9 @@
 # wallabag 2.x
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Gehe auf der alten wallabag-Instanz, die du vorher genutzt hast, auf
 Alle Artikel und exportiere diese dann als JSON.
 

--- a/de/user/tags.md
+++ b/de/user/tags.md
@@ -1,2 +1,6 @@
 Tags
 ====
+
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}

--- a/de/user/tags.md
+++ b/de/user/tags.md
@@ -2,5 +2,5 @@ Tags
 ====
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Diese übersetzte Dokumentation ist möglicherweise veraltet. Neuere Funktionen oder Anforderungen finden Sie in der [englischen Dokumentation](https://doc.wallabag.org/en/).
 {% endhint %}

--- a/it/README.md
+++ b/it/README.md
@@ -2,7 +2,7 @@ Documentazione di wallabag
 ==========================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ![wallabag logo](../img/wallabag.png)

--- a/it/README.md
+++ b/it/README.md
@@ -1,6 +1,10 @@
 Documentazione di wallabag
 ==========================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ![wallabag logo](../img/wallabag.png)
 
 **wallabag** è un'applicazione read-it-later: salva una pagina web

--- a/it/SUMMARY.md
+++ b/it/SUMMARY.md
@@ -1,5 +1,9 @@
 # Sommario
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 * [Home](README.md)
 
 ## Utente

--- a/it/SUMMARY.md
+++ b/it/SUMMARY.md
@@ -1,7 +1,7 @@
 # Sommario
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 * [Home](README.md)

--- a/it/admin/asynchronous.md
+++ b/it/admin/asynchronous.md
@@ -1,6 +1,10 @@
 Compiti Asincroni
 =================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Per avviare compiti asincroni (utile ad esempio per grandi
 importazioni), Potete usare RabbitMQ o Redis.
 

--- a/it/admin/asynchronous.md
+++ b/it/admin/asynchronous.md
@@ -2,7 +2,7 @@ Compiti Asincroni
 =================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Per avviare compiti asincroni (utile ad esempio per grandi

--- a/it/admin/backup.md
+++ b/it/admin/backup.md
@@ -2,7 +2,7 @@ Eseguire il backup di wallabag
 ==============================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Siccome a volte potreste commettere errori con il vostro wallabag e

--- a/it/admin/backup.md
+++ b/it/admin/backup.md
@@ -1,6 +1,10 @@
 Eseguire il backup di wallabag
 ==============================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Siccome a volte potreste commettere errori con il vostro wallabag e
 perdere i vostri dati, oppure in caso dobbiate spostare il vostro
 wallabag su un altro server, dovete fare un backup dei vostri dati.

--- a/it/admin/console_commands.md
+++ b/it/admin/console_commands.md
@@ -1,5 +1,9 @@
 # Comandi Console
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 
 wallabag possiede alcuni comandi CLI per gestire alcuni compiti. Potete elencare tutti i comandi eseguendo `bin/console` nella cartella wallabag.
 

--- a/it/admin/console_commands.md
+++ b/it/admin/console_commands.md
@@ -1,7 +1,7 @@
 # Comandi Console
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 
@@ -99,7 +99,7 @@ Opzioni:
 wallabag:import:redis-worker
 --------------------------------------
 
-Questo comando vi aiuta ad avviare il worker di Redis.		
+Questo comando vi aiuta ad avviare il worker di Redis.
 
 Uso:
 

--- a/it/admin/installation/README.md
+++ b/it/admin/installation/README.md
@@ -1,2 +1,6 @@
 Installa wallabag
 =================
+
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}

--- a/it/admin/installation/README.md
+++ b/it/admin/installation/README.md
@@ -2,5 +2,5 @@ Installa wallabag
 =================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}

--- a/it/admin/installation/installation.md
+++ b/it/admin/installation/installation.md
@@ -1,6 +1,10 @@
 Installazione
 -------------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ### Su un web server dedicato (raccomandato)
 
 Per installare wallabag stesso dovete eseguire i seguenti comandi:

--- a/it/admin/installation/installation.md
+++ b/it/admin/installation/installation.md
@@ -2,7 +2,7 @@ Installazione
 -------------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ### Su un web server dedicato (raccomandato)

--- a/it/admin/installation/requirements.md
+++ b/it/admin/installation/requirements.md
@@ -1,6 +1,10 @@
 Requisiti
 ---------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 wallabag è compatibile con PHP &gt;= 5.6, incluso PHP 7.
 
 {% hint style="info" %}

--- a/it/admin/installation/requirements.md
+++ b/it/admin/installation/requirements.md
@@ -2,7 +2,7 @@ Requisiti
 ---------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag è compatibile con PHP &gt;= 5.6, incluso PHP 7.

--- a/it/admin/installation/rightaccess.md
+++ b/it/admin/installation/rightaccess.md
@@ -1,5 +1,9 @@
 # Diritti di accesso alle cartelle del progetto
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Ambiente di test
 
 Quando vorrete solamente testare wallabag, eseguite il comando

--- a/it/admin/installation/rightaccess.md
+++ b/it/admin/installation/rightaccess.md
@@ -1,7 +1,7 @@
 # Diritti di accesso alle cartelle del progetto
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Ambiente di test

--- a/it/admin/installation/virtualhosts.md
+++ b/it/admin/installation/virtualhosts.md
@@ -1,7 +1,7 @@
 # Host virtuali
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Configurazione su Apache

--- a/it/admin/installation/virtualhosts.md
+++ b/it/admin/installation/virtualhosts.md
@@ -1,5 +1,9 @@
 # Host virtuali
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Configurazione su Apache
 
 Non dimenticate di attivare la mod *rewrite* di Apache

--- a/it/admin/internal_settings.md
+++ b/it/admin/internal_settings.md
@@ -1,7 +1,7 @@
 # A cosa servono le impostazioni interne?
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 La pagina delle impostazioni interne è disponibile solo per l'amministratore dell'istanza. Questa permette di gestire impostazioni più sensibili, come l'attivazione di alcune funzioni.

--- a/it/admin/internal_settings.md
+++ b/it/admin/internal_settings.md
@@ -1,5 +1,9 @@
 # A cosa servono le impostazioni interne?
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 La pagina delle impostazioni interne è disponibile solo per l'amministratore dell'istanza. Questa permette di gestire impostazioni più sensibili, come l'attivazione di alcune funzioni.
 
 ## Analytics

--- a/it/admin/parameters.md
+++ b/it/admin/parameters.md
@@ -1,5 +1,9 @@
 # Qual'è il significato dei parametri?
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## File parameters.yml di default
 
 Ecco l'ultima versione del file app/config/parameters.yml di default.

--- a/it/admin/parameters.md
+++ b/it/admin/parameters.md
@@ -1,7 +1,7 @@
 # Qual'è il significato dei parametri?
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## File parameters.yml di default

--- a/it/admin/query-upgrade-21-22.md
+++ b/it/admin/query-upgrade-21-22.md
@@ -1,7 +1,7 @@
 # Migrazione 20161001072726
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## MySQL

--- a/it/admin/query-upgrade-21-22.md
+++ b/it/admin/query-upgrade-21-22.md
@@ -1,5 +1,9 @@
 # Migrazione 20161001072726
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## MySQL
 
 ### Migrazione su

--- a/it/admin/upgrade.md
+++ b/it/admin/upgrade.md
@@ -1,5 +1,9 @@
 # Aggiornate la vostra installazione di wallabag
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Troverete qui i differenti modi per aggiornare il vostro wallabag:
 
 -   [da 2.0.x a 2.1.1](#aggiornamento-da-2-1-x-a-2-2-x)

--- a/it/admin/upgrade.md
+++ b/it/admin/upgrade.md
@@ -1,7 +1,7 @@
 # Aggiornate la vostra installazione di wallabag
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Troverete qui i differenti modi per aggiornare il vostro wallabag:
@@ -101,7 +101,7 @@ php bin/console cache:clear --env=prod
 
 ### Aggiornamento su un hosting condiviso
 
-Fate un backup del file `app/config/parameters.yml`. 
+Fate un backup del file `app/config/parameters.yml`.
 
 Scaricate la versione 2.1.1 di wallabag:
 

--- a/it/apps/android.md
+++ b/it/apps/android.md
@@ -1,7 +1,7 @@
 # Applicazione Android
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Scopo di questo documento

--- a/it/apps/android.md
+++ b/it/apps/android.md
@@ -1,5 +1,9 @@
 # Applicazione Android
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Scopo di questo documento
 
 Questo documento spiega come configurare la vostra applicazione Android

--- a/it/developer/api/methods.md
+++ b/it/developer/api/methods.md
@@ -1,7 +1,7 @@
 # Ottenere articoli esistenti
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Documentazione per questo metodo:

--- a/it/developer/api/methods.md
+++ b/it/developer/api/methods.md
@@ -1,5 +1,9 @@
 # Ottenere articoli esistenti
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Documentazione per questo metodo:
 https://app.wallabag.it/api/doc#get--api-entries.{_format}
 

--- a/it/developer/api/oauth.md
+++ b/it/developer/api/oauth.md
@@ -1,7 +1,7 @@
 # Creare un nuovo client API
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Sul vostro account wallabag potete creare un nuovo client API presso

--- a/it/developer/api/oauth.md
+++ b/it/developer/api/oauth.md
@@ -1,5 +1,9 @@
 # Creare un nuovo client API
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Sul vostro account wallabag potete creare un nuovo client API presso
 questo URL https://app.wallabag.it/developer/client/create.
 

--- a/it/developer/api/readme.md
+++ b/it/developer/api/readme.md
@@ -1,7 +1,7 @@
 # Documentazione su API
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Grazie a questa documentazione, vedremo come interagire con l'API di

--- a/it/developer/api/readme.md
+++ b/it/developer/api/readme.md
@@ -1,5 +1,9 @@
 # Documentazione su API
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Grazie a questa documentazione, vedremo come interagire con l'API di
 wallabag.
 

--- a/it/developer/api/resources.md
+++ b/it/developer/api/resources.md
@@ -1,5 +1,9 @@
 # Risorse di terze parti
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Alcune applicazioni o librerie usano le nostre API. Ecco una lista non
 esaustiva:
 

--- a/it/developer/api/resources.md
+++ b/it/developer/api/resources.md
@@ -1,7 +1,7 @@
 # Risorse di terze parti
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Alcune applicazioni o librerie usano le nostre API. Ecco una lista non

--- a/it/developer/docker.md
+++ b/it/developer/docker.md
@@ -1,7 +1,7 @@
 # Eseguire wallabag in docker-compose
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Per eseguire la vostra istanza di sviluppo di wallabag, dovreste

--- a/it/developer/docker.md
+++ b/it/developer/docker.md
@@ -1,5 +1,9 @@
 # Eseguire wallabag in docker-compose
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Per eseguire la vostra istanza di sviluppo di wallabag, dovreste
 usare i file docker compose preconfigurati.
 

--- a/it/developer/documentation.md
+++ b/it/developer/documentation.md
@@ -1,6 +1,10 @@
 Contribuire a questa documentazione
 ===================================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Le fonti della nostra documentazione sono qui
 https://github.com/wallabag/doc/
 

--- a/it/developer/documentation.md
+++ b/it/developer/documentation.md
@@ -2,7 +2,7 @@ Contribuire a questa documentazione
 ===================================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Le fonti della nostra documentazione sono qui

--- a/it/developer/front_end.md
+++ b/it/developer/front_end.md
@@ -1,7 +1,7 @@
 # Consigli per sviluppatori front-end
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Iniziando dalla versione 2.3, wallabag usa webpack per raggruppare le sue risorse.

--- a/it/developer/front_end.md
+++ b/it/developer/front_end.md
@@ -1,5 +1,9 @@
 # Consigli per sviluppatori front-end
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Iniziando dalla versione 2.3, wallabag usa webpack per raggruppare le sue risorse.
 
 ## Modalità sviluppatore

--- a/it/developer/paywall.md
+++ b/it/developer/paywall.md
@@ -1,7 +1,7 @@
 # Configurare l'accesso al paywall
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 {% hint style="working" %}

--- a/it/developer/paywall.md
+++ b/it/developer/paywall.md
@@ -1,5 +1,9 @@
 # Configurare l'accesso al paywall
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 {% hint style="working" %}
 Questa è la parte tecnica a proposito del paywall. Se state cercando la sezione dedicata all'utente, si prega di leggere [questa pagina](../user/articles/restricted.md).
 {% endhint %}

--- a/it/developer/testsuite.md
+++ b/it/developer/testsuite.md
@@ -2,11 +2,11 @@ Testsuite
 =========
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Per assicurare la qualità di sviluppo di wallabag, abbiamo scritto i
-test con [PHPUnit](https://phpunit.de). 
+test con [PHPUnit](https://phpunit.de).
 
 Se contribuite al progetto
 (traducendo l'applicazione, risolvendo i bug o aggiungendo nuove

--- a/it/developer/testsuite.md
+++ b/it/developer/testsuite.md
@@ -1,6 +1,10 @@
 Testsuite
 =========
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Per assicurare la qualità di sviluppo di wallabag, abbiamo scritto i
 test con [PHPUnit](https://phpunit.de). 
 

--- a/it/developer/translate.md
+++ b/it/developer/translate.md
@@ -1,7 +1,7 @@
 # Tradurre wallabag
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## wallabag web app

--- a/it/developer/translate.md
+++ b/it/developer/translate.md
@@ -1,5 +1,9 @@
 # Tradurre wallabag
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## wallabag web app
 
 ### File per la traduzione

--- a/it/user/articles/README.md
+++ b/it/user/articles/README.md
@@ -1,7 +1,7 @@
 # Articoli
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Gli articoli sono la caratteristica principale di wallabag. Il parser del contenuto di wallabag, chiamato Graby, prende solamente il contenuto dagli articoli.

--- a/it/user/articles/README.md
+++ b/it/user/articles/README.md
@@ -1,5 +1,9 @@
 # Articoli
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Gli articoli sono la caratteristica principale di wallabag. Il parser del contenuto di wallabag, chiamato Graby, prende solamente il contenuto dagli articoli.
 
 ## Mark articles as read

--- a/it/user/articles/annotations.md
+++ b/it/user/articles/annotations.md
@@ -1,5 +1,9 @@
 # Annotate i vostri articoli
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 in ogni articolo che leggete potete scrivere delle note. È più facile
 da capire con delle immagini.
 

--- a/it/user/articles/annotations.md
+++ b/it/user/articles/annotations.md
@@ -1,7 +1,7 @@
 # Annotate i vostri articoli
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 in ogni articolo che leggete potete scrivere delle note. È più facile

--- a/it/user/articles/download.md
+++ b/it/user/articles/download.md
@@ -1,7 +1,7 @@
 ## Scaricate i vostri articoli
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Potete scaricare ogni articolo in vari formati: ePUB, MOBI, PDF, XML,

--- a/it/user/articles/download.md
+++ b/it/user/articles/download.md
@@ -1,5 +1,9 @@
 ## Scaricate i vostri articoli
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Potete scaricare ogni articolo in vari formati: ePUB, MOBI, PDF, XML,
 JSON, CSV.
 

--- a/it/user/articles/restricted.md
+++ b/it/user/articles/restricted.md
@@ -1,5 +1,9 @@
 # Articoli con accesso ristretto
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 wallabag ha un sistema per ottenere articoli dietro ad un paywall, offrendo le vostre credenziali quando l'articolo viene ottenuto.
 
 Nella versione 2.2, solo l'amministratore poteva inserire le proprie credenziali nel file di configurazione, rendendo la funzionalità accessibile a tutti gli utenti dell'istanza. Dalla versione 2.3, tutti gli utenti hanno un pannello in cui inserire le proprie credenziali.

--- a/it/user/articles/restricted.md
+++ b/it/user/articles/restricted.md
@@ -1,7 +1,7 @@
 # Articoli con accesso ristretto
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag ha un sistema per ottenere articoli dietro ad un paywall, offrendo le vostre credenziali quando l'articolo viene ottenuto.

--- a/it/user/articles/save.md
+++ b/it/user/articles/save.md
@@ -1,6 +1,10 @@
 
 # Salvare articoli
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Il proposito principale di wallabag è di salvare articoli web, e potete
 farlo in molti modi. Se pensate che l'articolo sia mostrato in modo
 sbagliato, [potete leggere questa documentazione](../errors_during_fetching.md).

--- a/it/user/articles/save.md
+++ b/it/user/articles/save.md
@@ -2,7 +2,7 @@
 # Salvare articoli
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Il proposito principale di wallabag è di salvare articoli web, e potete

--- a/it/user/articles/share.md
+++ b/it/user/articles/share.md
@@ -1,5 +1,9 @@
 # Condividete i vostri articoli
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Quando leggete un articolo, potete condividerlo. Cliccate semplicemente
 sul bottone di condivisione:
 

--- a/it/user/articles/share.md
+++ b/it/user/articles/share.md
@@ -1,7 +1,7 @@
 # Condividete i vostri articoli
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Quando leggete un articolo, potete condividerlo. Cliccate semplicemente

--- a/it/user/configuration/README.md
+++ b/it/user/configuration/README.md
@@ -1,5 +1,9 @@
 # Configurazione
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Ora che siete acceduti, é ora di configurare il vostro account come
 volete.
 

--- a/it/user/configuration/README.md
+++ b/it/user/configuration/README.md
@@ -1,7 +1,7 @@
 # Configurazione
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Ora che siete acceduti, é ora di configurare il vostro account come

--- a/it/user/configuration/password.md
+++ b/it/user/configuration/password.md
@@ -3,7 +3,7 @@ Password
 --------
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Qui potete cambiare la password (minimo 8 caratteri)

--- a/it/user/configuration/password.md
+++ b/it/user/configuration/password.md
@@ -2,4 +2,8 @@
 Password
 --------
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Qui potete cambiare la password (minimo 8 caratteri)

--- a/it/user/configuration/rss.md
+++ b/it/user/configuration/rss.md
@@ -2,7 +2,7 @@ RSS
 ---
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 wallabag offre feed RSS per ogni stato dell'articolo: non letto,

--- a/it/user/configuration/rss.md
+++ b/it/user/configuration/rss.md
@@ -1,6 +1,9 @@
-
 RSS
 ---
+
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
 
 wallabag offre feed RSS per ogni stato dell'articolo: non letto,
 preferito e archiviato.

--- a/it/user/configuration/settings.md
+++ b/it/user/configuration/settings.md
@@ -1,7 +1,7 @@
 # Impostazioni
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Tema

--- a/it/user/configuration/settings.md
+++ b/it/user/configuration/settings.md
@@ -1,4 +1,9 @@
 # Impostazioni
+
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Tema
 
 wallabag è personalizzabile. Potete scegliere il vostro tema preferito

--- a/it/user/configuration/tagging_rules.md
+++ b/it/user/configuration/tagging_rules.md
@@ -1,7 +1,7 @@
 # Regole di etichettatura
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Se volete assegnare un'etichetta ai nuovi articoli, questa parte della
@@ -33,7 +33,7 @@ di tagging (attenzione, per alcuni valori, dovete aggiungere le
 virgolette, per esempio `language = "en"`):
 
 
-  Variable      | Significato                                          
+  Variable      | Significato
   ------------- | -------------------
   title         | Titolo dell'articolo
   url           | URL dell'articolo

--- a/it/user/configuration/tagging_rules.md
+++ b/it/user/configuration/tagging_rules.md
@@ -1,5 +1,9 @@
 # Regole di etichettatura
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Se volete assegnare un'etichetta ai nuovi articoli, questa parte della
 configurazione fa per voi.
 

--- a/it/user/configuration/user_information.md
+++ b/it/user/configuration/user_information.md
@@ -1,7 +1,7 @@
 # Informazioni utente
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Potete cambiare il vostro nome, il vostro indirizzo e-mail e abilitare

--- a/it/user/configuration/user_information.md
+++ b/it/user/configuration/user_information.md
@@ -1,5 +1,9 @@
 # Informazioni utente
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Potete cambiare il vostro nome, il vostro indirizzo e-mail e abilitare
 l'`Autenticazione a due fattori`.
 

--- a/it/user/configuring_mobile.md
+++ b/it/user/configuring_mobile.md
@@ -2,7 +2,7 @@ Configurare le app mobili in modo che funzionino con wallabag
 =============================================================
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Passi per configurare l'app

--- a/it/user/configuring_mobile.md
+++ b/it/user/configuring_mobile.md
@@ -1,6 +1,10 @@
 Configurare le app mobili in modo che funzionino con wallabag
 =============================================================
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Passi per configurare l'app
 ---------------------------
 

--- a/it/user/create_account.md
+++ b/it/user/create_account.md
@@ -1,7 +1,7 @@
 # Creare di un account ed autenticarsi
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Registrazione

--- a/it/user/create_account.md
+++ b/it/user/create_account.md
@@ -1,5 +1,9 @@
 # Creare di un account ed autenticarsi
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Registrazione
 
 Sulla pagina di accesso, cliccate sul bottone `Registrati`

--- a/it/user/errors_during_fetching.md
+++ b/it/user/errors_during_fetching.md
@@ -1,7 +1,7 @@
 # Errori nell'ottenere gli articoli
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Perché l'ottenimento di un articolo fallisce?

--- a/it/user/errors_during_fetching.md
+++ b/it/user/errors_during_fetching.md
@@ -1,5 +1,9 @@
 # Errori nell'ottenere gli articoli
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Perché l'ottenimento di un articolo fallisce?
 
 Ci possono essere varie ragioni:

--- a/it/user/faq.md
+++ b/it/user/faq.md
@@ -1,5 +1,9 @@
 # Domande frequenti
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Durante l'installazione ho riscontrato l'errore `Error Output: sh: 1: @post-cmd: not found`
 
 Sembra che ci sia un problema con la vostra installazione di `composer`.

--- a/it/user/faq.md
+++ b/it/user/faq.md
@@ -1,7 +1,7 @@
 # Domande frequenti
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Durante l'installazione ho riscontrato l'errore `Error Output: sh: 1: @post-cmd: not found`

--- a/it/user/filters.md
+++ b/it/user/filters.md
@@ -1,5 +1,9 @@
 # Trovate i vostri articoli grazie ai filtri
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Per trovare facilmente gli articoli, potete usare i filtri. Cliccate sulla terza icona nella barra superiore.
 
 ![Barra superiore](../../img/user/topbar.png)

--- a/it/user/filters.md
+++ b/it/user/filters.md
@@ -1,7 +1,7 @@
 # Trovate i vostri articoli grazie ai filtri
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Per trovare facilmente gli articoli, potete usare i filtri. Cliccate sulla terza icona nella barra superiore.

--- a/it/user/import.md
+++ b/it/user/import.md
@@ -1,1 +1,5 @@
 
+
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}

--- a/it/user/import.md
+++ b/it/user/import.md
@@ -1,5 +1,5 @@
 
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}

--- a/it/user/import/Instapaper.md
+++ b/it/user/import/Instapaper.md
@@ -1,5 +1,9 @@
 # Instapaper
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Esportate i vostri dati di Instapaper
 
 Sulla pagina delle impostazioni

--- a/it/user/import/Instapaper.md
+++ b/it/user/import/Instapaper.md
@@ -1,7 +1,7 @@
 # Instapaper
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Esportate i vostri dati di Instapaper

--- a/it/user/import/Pinboard.md
+++ b/it/user/import/Pinboard.md
@@ -1,7 +1,7 @@
 # Da Pinboard
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Esportate i vostri dati di Pinboard

--- a/it/user/import/Pinboard.md
+++ b/it/user/import/Pinboard.md
@@ -1,5 +1,9 @@
 # Da Pinboard
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Esportate i vostri dati di Pinboard
 
 Nella pagina backup

--- a/it/user/import/Pocket.md
+++ b/it/user/import/Pocket.md
@@ -1,7 +1,7 @@
 # Pocket
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Create una nuova applicazione su Pocket

--- a/it/user/import/Pocket.md
+++ b/it/user/import/Pocket.md
@@ -1,5 +1,9 @@
 # Pocket
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Create una nuova applicazione su Pocket
 
 Per importare dati da Pocket usiamo l'API di Pocket. Dovete creare una

--- a/it/user/import/README.md
+++ b/it/user/import/README.md
@@ -1,7 +1,7 @@
 # Migrare da...
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 In wallabag 2.x, potete importare dati da:
@@ -34,7 +34,7 @@ Si prega di rimpiazzare i valori:
     file esportato da wallabag v1
 
 Se volete segnare tutti questi articoli come già letti, potete
-aggiungere l'opzione `--markAsRead`. 
+aggiungere l'opzione `--markAsRead`.
 
 Per importare un file di wallabag
 v2, dovete aggiungere l'opzione `--importer=v2`.

--- a/it/user/import/README.md
+++ b/it/user/import/README.md
@@ -1,5 +1,9 @@
 # Migrare da...
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 In wallabag 2.x, potete importare dati da:
 
 -   [Pocket](Pocket.md)

--- a/it/user/import/Readability.md
+++ b/it/user/import/Readability.md
@@ -1,7 +1,7 @@
 # Readability
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 ## Esportate i vostri dati di Readability

--- a/it/user/import/Readability.md
+++ b/it/user/import/Readability.md
@@ -1,5 +1,9 @@
 # Readability
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 ## Esportate i vostri dati di Readability
 
 Nella pagina tools

--- a/it/user/import/wallabagv1.md
+++ b/it/user/import/wallabagv1.md
@@ -1,7 +1,7 @@
 # wallabag 1.x
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Se state usando wallabag 1.x, dovete esportare i dati prima di migrare a

--- a/it/user/import/wallabagv1.md
+++ b/it/user/import/wallabagv1.md
@@ -1,5 +1,9 @@
 # wallabag 1.x
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Se state usando wallabag 1.x, dovete esportare i dati prima di migrare a
 wallabag 2.x, poiché l'applicazione ed il suo database sono cambiati
 molto. Potete esportare i vostri dati dalla vostra vecchia installazione

--- a/it/user/import/wallabagv2.md
+++ b/it/user/import/wallabagv2.md
@@ -1,5 +1,9 @@
 # wallabag 2.x
 
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}
+
 Dalla istanza di wallabag precedente sulla quale eravate prima, andate
 su Tutti gli articoli, poi esportate questi articoli come json.
 

--- a/it/user/import/wallabagv2.md
+++ b/it/user/import/wallabagv2.md
@@ -1,7 +1,7 @@
 # wallabag 2.x
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}
 
 Dalla istanza di wallabag precedente sulla quale eravate prima, andate

--- a/it/user/tags.md
+++ b/it/user/tags.md
@@ -1,5 +1,5 @@
 # Tags
 
 {% hint style="danger" %}
-This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+Questa documentazione tradotta potrebbe non essere aggiornata. Per funzionalità o requisiti più recenti, consultare la [documentazione inglese](https://doc.wallabag.org/en/).
 {% endhint %}

--- a/it/user/tags.md
+++ b/it/user/tags.md
@@ -1,1 +1,5 @@
 # Tags
+
+{% hint style="danger" %}
+This translated documentation might be out of date. For more recent features or requirements, please refer to the [English documentation](https://doc.wallabag.org/en/).
+{% endhint %}


### PR DESCRIPTION
Following #88, I added a warning to all DE & IT translations containing a link towards the English documentation.