### PR TITLE
Graby debug(s) mode activation

### DIFF
--- a/en/user/errors_during_fetching.md
+++ b/en/user/errors_during_fetching.md
@@ -60,7 +60,7 @@ monolog:
         graby:
             type: stream
             path: "%kernel.logs_dir%/graby.log"
-            level: debug
+            level: info
             channels: ['graby']
         console:
             type: console
@@ -68,7 +68,11 @@ monolog:
 - empty the cache with the command `rm -rf var/cache/*`;
 - reload wallabag in your browser and re-fetch the content.
 
-If you can't solve the issue with the detailed logs, paste the file `var/logs/graby.log` in [a new issue on GitHub](https://github.com/wallabag/wallabag/issues/new).
+More detailed logs will then be available in `var/logs/graby.log`, with most of the steps taken by graby to try and fetch your article. If you can't solve the issue with these logs, paste the file `var/logs/graby.log` in [a new issue on GitHub](https://github.com/wallabag/wallabag/issues/new).
+
+{% hint style="tip" %} It is possible to have **extremely** detailed logs on the modifications made by graby while fetching, parsing and cleaning the HTML code of one article, using `level: debug` instead of `level: info` in the `graby:` section above.
+
+It is very useful when writing site configuration file (see below); one must note however that all the HTML code is stored in all its intermediary states and that the log file will grow very rapidly. Use with caution :){% endhint %}
 
 ### Creation/update of a site configuration file
 

--- a/fr/user/errors_during_fetching.md
+++ b/fr/user/errors_during_fetching.md
@@ -60,7 +60,7 @@ monolog:
         graby:
             type: stream
             path: "%kernel.logs_dir%/graby.log"
-            level: debug
+            level: info
             channels: ['graby']
         console:
             type: console
@@ -68,7 +68,11 @@ monolog:
 - videz le cache avec la commande `rm -rf var/cache/*` ;
 - rechargez votre instance wallabag et rechargez le contenu qui pose souci.
 
-Si vous ne réussissez pas à déterminer avec les logs l'origine du problème, copiez/collez le contenu du fichier `var/logs/graby.log` dans un nouveau [ticket d'incident GitHub](https://github.com/wallabag/wallabag/issues/new).
+Vous aurez désormais dans le fichier `var/logs/graby.log` des détails sur les différentes étapes effectuées par graby (l'analyseur de contenu de wallabag). Si vous ne réussissez pas à déterminer avec ces logs l'origine du problème, copiez/collez le contenu du fichier `var/logs/graby.log` dans un nouveau [ticket d'incident GitHub](https://github.com/wallabag/wallabag/issues/new).
+
+{% hint style="tip" %}Il est possible d'obtenir des informations **extrêmement** détaillées sur les modifications effectuées par graby lors de la récupération, l'analyse et le nettoyage du code d'un article en passant `level: debug` au lieu de `level: info` dans la section `graby:` ci-dessus.
+
+Cela peut être très pratique lors de fichiers de configuration (_site config_, voir ci-dessous) ; il faut cependant être conscient que l'activation du `level: debug` engendre le stockage du code HTML complet de l'article à plusieurs étapes du traitement. Le fichier de log va donc grossir très rapidement ! :){% endhint %}
 
 ### Création ou mise à jour d'un fichier de configuration (_site config_)
 

--- a/fr/user/errors_during_fetching.md
+++ b/fr/user/errors_during_fetching.md
@@ -72,7 +72,7 @@ Vous aurez désormais dans le fichier `var/logs/graby.log` des détails sur les 
 
 {% hint style="tip" %}Il est possible d'obtenir des informations **extrêmement** détaillées sur les modifications effectuées par graby lors de la récupération, l'analyse et le nettoyage du code d'un article en passant `level: debug` au lieu de `level: info` dans la section `graby:` ci-dessus.
 
-Cela peut être très pratique lors de fichiers de configuration (_site config_, voir ci-dessous) ; il faut cependant être conscient que l'activation du `level: debug` engendre le stockage du code HTML complet de l'article à plusieurs étapes du traitement. Le fichier de log va donc grossir très rapidement ! :){% endhint %}
+Cela peut être très pratique lors de la création de fichiers de configuration (_site config_, voir ci-dessous) ; il faut cependant être conscient que l'activation du `level: debug` engendre le stockage du code HTML complet de l'article à plusieurs étapes du traitement. Le fichier de log va donc grossir très rapidement ! :){% endhint %}
 
 ### Création ou mise à jour d'un fichier de configuration (_site config_)
 


### PR DESCRIPTION
I updated the FR & EN documentation, following the merge of a "full debug mode" for graby.
Fix https://github.com/wallabag/wallabag/issues/3801

Merge only if the weird behavior of wallabag regarding graby's logs configuration is acceptable.