### PR TITLE
📝 Add development required PHP extensions section

### DIFF
--- a/de/admin/installation/requirements.md
+++ b/de/admin/installation/requirements.md
@@ -40,6 +40,7 @@ installieren.
 -   php-gettext
 -   php-tokenizer
 -   php-bcmath
+-   php-intl
 
 wallabag nutzt PDO, um sich mit der Datenbank zu verbinden, darum
 benötigst du eines der folgenden Komponenten:

--- a/en/admin/installation/requirements.md
+++ b/en/admin/installation/requirements.md
@@ -40,6 +40,7 @@ You'll also need the following extensions. Some of these may already activated, 
 -   php-gettext
 -   php-tokenizer
 -   php-bcmath
+-   php-intl
 
 wallabag uses PDO to connect to the database, so you'll need one of the following:
 

--- a/fr/admin/installation/requirements.md
+++ b/fr/admin/installation/requirements.md
@@ -22,6 +22,8 @@ curl -s https://getcomposer.org/installer | php
 Vous pouvez trouver des instructions spécifiques [ici (en
 anglais)](https://getcomposer.org/doc/00-intro.md).
 
+## Extensions PHP
+
 Vous aurez besoin des extensions suivantes pour que wallabag fonctionne.
 Il est possible que certaines de ces extensions soient déjà activées
 dans votre version de PHP, donc vous n'avez pas forcément besoin
@@ -42,6 +44,7 @@ d'installer tous les paquets correspondants.
 -   php-gettext
 -   php-tokenizer
 -   php-bcmath
+-   php-intl
 
 wallabag utilise PDO afin de se connecter à une base de données, donc
 vous aurez besoin d'une extension et d'un système de bases de données

--- a/it/admin/installation/requirements.md
+++ b/it/admin/installation/requirements.md
@@ -42,6 +42,7 @@ i pacchetti corrispondenti.
 -   php-gettext
 -   php-tokenizer
 -   php-bcmath
+-   php-intl
 
 wallabag usa PDO per connettersi, per cui avrete bisogno di uno dei
 seguenti:


### PR DESCRIPTION
When running `make dev` to hack on Wallabag, some dependency fails because I didn’t have `php-intl` so I added a `PHP extensions for development` on the page of requirements.

Only added on `en` and `fr` languages, sorry.