### PR TITLE
Fix apache error on mod_rewrite section

### DIFF
--- a/en/admin/installation/virtualhosts.md
+++ b/en/admin/installation/virtualhosts.md
@@ -25,6 +25,7 @@ Installation in folders can work, but is not supported by the maintainers.
         Allow from All
 
         <IfModule mod_rewrite.c>
+            Options +SymLinksIfOwnerMatch
             Options -MultiViews
             RewriteEngine On
             RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Only adding RewriteRule makes apache return a Forbidden error with
the following message in the logs:

> Options FollowSymLinks and SymLinksIfOwnerMatch are both off, so the RewriteRule directive is also forbidden due to its similar ability to circumvent directory restrictions

This change avoids that issue.