### PR TITLE
Update cloudron app id

### DIFF
--- a/en/admin/installation/installation.md
+++ b/en/admin/installation/installation.md
@@ -78,7 +78,7 @@ packaged as a Cloudron app and available to install directly from the
 store.
 
 [Install wallabag on your
-Cloudron](https://cloudron.io/store/org.wallabag.cloudronapp.html)
+Cloudron](https://cloudron.io/store/org.wallabag.cloudronapp2.html)
 
 ## Installation on YunoHost
 


### PR DESCRIPTION
The wallabag app id was changed for migration to the latest version.