### PR TITLE
Use site with subdomain as tagging rule example

### DIFF
--- a/de/user/configuration/tagging_rules.md
+++ b/de/user/configuration/tagging_rules.md
@@ -25,7 +25,7 @@ gelesen* in das Tags-Feld. Mehrere Tags können gleichzeitig hinzugefügt
 werden, wenn man sie mit einem Komma trennt: *schnell gelesen,
 Pflichtlektüre*. Komplexe Regeln können mit vordefinierten Operatoren
 geschrieben werden: Wenn *readingTime &gt;= 5 AND domainName =
-"github.com"*, dann tagge als *lange zu lesen, github*.
+"www.php.net"*, dann tagge als *lange zu lesen, php*.
 
 ### Welche Variablen und Operatoren kann ich zum Regeln schreiben nutzen?
 

--- a/en/user/configuration/tagging_rules.md
+++ b/en/user/configuration/tagging_rules.md
@@ -19,7 +19,7 @@ readingTime &lt;= 3 » in the **Rule** field and *« short reading »* in
 the **Tags** field. Several tags can added simultaneously by separating
 them by a comma: *« short reading, must read »*. Complex rules can be
 written by using predefined operators: if *« readingTime &gt;= 5 AND
-domainName = "github.com" »* then tag as *« long reading, github »*.
+domainName = "www.php.net" »* then tag as *« long reading, php »*.
 
 ## Which variables and operators can I use to write rules?
 

--- a/fr/user/configuration/tagging_rules.md
+++ b/fr/user/configuration/tagging_rules.md
@@ -21,7 +21,7 @@ vous devez ajouter « readingTime &lt;= 3 » dans le champ **Règle** et
 ajoutés en même temps en les séparant par une virgule : *« lecture
 rapide, à lire »*. Des règles complexes peuvent être écrites en
 utilisant les opérateurs pré-définis : if *« readingTime &gt;= 5 AND
-domainName = "github.com" »* then tag as *« long reading, github »*.
+domainName = "www.php.net" »* then tag as *« long reading, php »*.
 
 ## Quels variables et opérateurs puis-je utiliser pour écrire mes règles ?
 

--- a/it/user/configuration/tagging_rules.md
+++ b/it/user/configuration/tagging_rules.md
@@ -23,8 +23,8 @@ dovreste mettere « readingTime &lt;= 3 » nel campo **Regola** e *«
 lettura corta »* nel campo **Etichette**. Molte etichette possono essere
 aggiunte simultaneamente separandole con una virgola: *« lettura corta,
 da leggere »*. Si possono scrivere regole complesse usando gli operatori
-predefiniti: se *« readingTime &gt;= 5 AND domainName = "github.com" »*
-allora etichetta come *« lettura lunga, github »*.
+predefiniti: se *« readingTime &gt;= 5 AND domainName = "www.php.net" »*
+allora etichetta come *« lettura lunga, php »*.
 
 Quali variabili ed operatori posso usare per scrivere le regole?
 


### PR DESCRIPTION
Use domain with subdomain `www.php.net` instead of `github.com` as `domainName` example in tagging rules docs. This should make it more clear that the subdomain is required for equality.

Fixes wallabag/doc#104
This change affects all translations in documentation and wallabag source.
Corresponding change in wallabag messages: wallabag/wallabag#5744