### PR TITLE
Correction of v25-26 upgrade typo

### DIFF
--- a/en/admin/query-upgrade-25-26.md
+++ b/en/admin/query-upgrade-25-26.md
@@ -19,7 +19,7 @@ ALTER TABLE wallabag_config ADD display_thumbnails INT(11) NOT NULL DEFAULT 1;
 ```sql
 ALTER TABLE wallabag_config DROP theme;
 ALTER TABLE wallabag_user ALTER backupcodes TYPE JSON USING backupcodes::json
-ALTER TABLE wallabag_config ADD display_thumbnails INT(11) NOT NULL DEFAULT 1;
+ALTER TABLE wallabag_config ADD display_thumbnails INT NOT NULL DEFAULT 1;
 ```
 
 ## SQLite


### PR DESCRIPTION
There is a typo left in the documentation for a postgres database. . In PostgreSQL, the INT data type does not have a length specifier like in some other database systems (e.g., MySQL).