### PR TITLE
Clarify that annotation is not visible on the internet

### DIFF
--- a/en/user/articles/annotations.md
+++ b/en/user/articles/annotations.md
@@ -1,6 +1,6 @@
 # Annotate your articles
 
-In each article you read, you can write annotations. It's easier to
+In each saved article you read, you can write annotations. It's easier to
 understand with some pictures.
 
 Select the part of the article that you want to annotate and click on
@@ -18,3 +18,4 @@ the mouse cursor over it.
 ![Read your annotation](../../../img/user/annotations_3.png)
 
 You can create as many annotations as you wish.
+Note that the annotation is visible when you read the article from wallabag, not when you browse the original page on the web.


### PR DESCRIPTION
Annotation is not visible when revisiting the original page on the internet. Only when visiting the wallabag saved version.