### PR TITLE
fix typos throughout the English docs

### DIFF
--- a/en/admin/common_errors.md
+++ b/en/admin/common_errors.md
@@ -1,6 +1,6 @@
 # Common errors
 
-Here is a list of commong errors that we saw in GitHub's issues.
+Here is a list of common errors that we have seen in GitHub's issues.
 
 ## Migration script assumes quote table names are enabled for MySQL
 
@@ -8,7 +8,7 @@ If during migration you got some problems with MySQL with an error like that:
 
 > SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"wallabag_entry" ADD uuid LONGTEXT DEFAULT NULL' at line 1
 
-It means you should enabled the `ANSI_QUOTES` of `SQL_MODE`.
+It means you should enable the `ANSI_QUOTES` of `SQL_MODE`.
 
 You can do that in your `app/config/config.yml` file:
 

--- a/en/admin/installation/installation.md
+++ b/en/admin/installation/installation.md
@@ -24,7 +24,7 @@ If you want to use SQLite to store your data, please put `%kernel.root_dir%/../d
 {% endhint %}
 
 {% hint style="info" %}
-If you're installing Wallabag behind Squid as a reverse proxy, make sure to update your `squid.conf` configuration to include `login=PASS` in the `cache_peer` line. This is necessary for API calls to work properly.
+If you're installing wallabag behind Squid as a reverse proxy, make sure to update your `squid.conf` configuration to include `login=PASS` in the `cache_peer` line. This is necessary for API calls to work properly.
 {% endhint %}
 
 ## On shared hosting
@@ -35,7 +35,7 @@ configuration uses MySQL for the database. To add the setting for your database,
 We have already created a user: the login and password are `wallabag`.
 
 With this package, wallabag doesn't check for mandatory extensions used
-in the application (theses checks are made during `composer install`
+in the application (these checks are made during `composer install`
 when you have a dedicated web server, see above).
 
 Execute this command to download and extract the latest package:

--- a/en/admin/internal_settings.md
+++ b/en/admin/internal_settings.md
@@ -28,7 +28,7 @@ URL of your Diaspora\* instance.
 
 ### Enable authentication for websites with paywall
 
-`1` to activate authentification for articles with a paywall (ex: Mediapart, Next INpact, etc.).
+`1` to activate authentication for articles with a paywall (ex: Mediapart, Next INpact, etc.).
 
 ### Shaarli URL, if the service is enabled
 

--- a/en/apps/android.md
+++ b/en/apps/android.md
@@ -9,7 +9,7 @@ procedure for wallabag v1 or v2.
 ## Steps to configure your app
 
 When you first start the app, you see the welcome screen, where you are
-adviced to configure the app for your wallabag instance at first.
+advised to configure the app for your wallabag instance at first.
 
 ![Welcome screen](../../img/user/android_welcome_screen.en.png)
 

--- a/en/user/articles/README.md
+++ b/en/user/articles/README.md
@@ -4,7 +4,7 @@ Articles are the core feature of wallabag. wallabag's content parser, named Grab
 
 ## Mark articles as read
 
-When you mark an article as read, it gets out of the category « Unread » and gets puts in the « Archive » category.
+When you mark an article as read, it moves from the category « Unread » to in the « Archive » category.
 
 ## Favorite articles
 

--- a/en/user/articles/README.md
+++ b/en/user/articles/README.md
@@ -4,7 +4,7 @@ Articles are the core feature of wallabag. wallabag's content parser, named Grab
 
 ## Mark articles as read
 
-When you mark an article as read, it moves from the category « Unread » to in the « Archive » category.
+When you mark an article as read, it moves from the category « Unread » to the « Archive » category.
 
 ## Favorite articles
 

--- a/en/user/articles/save.md
+++ b/en/user/articles/save.md
@@ -144,7 +144,7 @@ The article window consists from:
 
    ![Edit title](../../../img/user/wallabagger/use-edittitle.png)
 
-  - set archived and starred flags icons ![Flags icons](../../../img/user/wallabagger/use-flagsicons.png) These icons change its appeareance when the flags are set ![Flags is set](../../../img/user/wallabagger/use-flagsset.png)
+  - set archived and starred flags icons ![Flags icons](../../../img/user/wallabagger/use-flagsicons.png) These icons change its appearance when the flags are set ![Flags is set](../../../img/user/wallabagger/use-flagsset.png)
   - delete article icon ![Delete icon](../../../img/user/wallabagger/use-deleteicon.png) clicking it opens a confirmation dialog  to make sure you want to delete your article
 
    ![Delete dialog](../../../img/user/wallabagger/use-deletedialog.png)
@@ -176,5 +176,5 @@ or on
 
 ### Windows Phone
 
-You can downlaod the [Windows Phone application
+You can download the [Windows Phone application
 here](https://www.microsoft.com/store/apps/9nblggh5x3p6).

--- a/en/user/configuration/settings.md
+++ b/en/user/configuration/settings.md
@@ -1,7 +1,7 @@
 # Settings
 ## Theme
 
-wallabag is customizable. You can choose your prefered theme here. The
+wallabag is customizable. You can choose your preferred theme here. The
 default theme is `Material`, it's the theme used in the documentation
 screenshots.
 

--- a/en/user/create_account.md
+++ b/en/user/create_account.md
@@ -6,7 +6,7 @@ On the login page, click on `Register` button.
 
 ![Registration form](../../img/user/registration_form.png)
 
-You have to fill the form. Please sure to type a valid email address,
+You have to fill the form. Please be sure to type a valid email address,
 we'll send you an activation email.
 
 ![Email was sent to activate account](../../img/user/sent_email.png)

--- a/en/user/errors_during_fetching.md
+++ b/en/user/errors_during_fetching.md
@@ -19,7 +19,7 @@ By default, if a website can't be fetched because of a request error (a page not
 If you find a line starting with `graby.ERROR` during the timeframe of your test, it means the request failed because of an error. The status code of the error can already give you a hint of the issue:
 
 - a `404` code means that wallabag couldn't find the article at the given address;
-- a `403` code means that access to the page is forbidden (either because of a misconfiguration of the remote server or because the host has taken anti-scrapping measures);
+- a `403` code means that access to the page is forbidden (either because of a misconfiguration of the remote server or because the host has taken anti-scraping measures);
 - a `500` code might indicate an issue with the remote server or your internet connection;
 - `504` or `408` codes could indicate a time-out in the connection with the server.
 

--- a/en/user/import/Readability.md
+++ b/en/user/import/Readability.md
@@ -5,7 +5,7 @@
 On the tools
 ([<https://www.readability.com/tools/>](https://www.readability.com/tools/))
 page, click on "Export your data" in the "Data Export" section. You will
-received an email to download a json (which does not end with .json in
+receive an email to download a json (which does not end with .json in
 fact).
 
 ## Import your data into wallabag

--- a/en/user/tags.md
+++ b/en/user/tags.md
@@ -5,8 +5,8 @@ Tags are a great way of organizing your saved content in order to more easily ac
 
 ## Adding Tags
 
-Tags may be added when saving content (e.g. using the Chrome extension Wallabagger) or by opening the content in Wallabag and clicking the "Add a Tag" button on the sidebar.
+Tags may be added when saving content (e.g. using the Chrome extension Wallabagger) or by opening the content in wallabag and clicking the "Add a Tag" button on the sidebar.
 
-## Retreiving Content by Tag
+## Retrieving Content by Tag
 
 From the home page, simply click tags on the sidebar in order to access your list of content tags. Click the your tag to access any content which is labeled with it! 

--- a/fr/developer/api/resources.md
+++ b/fr/developer/api/resources.md
@@ -20,6 +20,6 @@ une liste non exhaustive :
     graphe](https://codeberg.org/strubbl/wallabag-stats) et l'outil de
     ligne de commande
     [wallabag-add-article](https://codeberg.org/strubbl/wallabag-add-article).
--   Tool to automatically download Wallabag articles into your local
+-   Tool to automatically download wallabag articles into your local
     computer or Kobo ebook reader
     [wallabako](https://gitlab.com/anarcat/wallabako) par anarcat.


### PR DESCRIPTION
I noted a few typos and so went ahead and fixed them while also running codespell to detect a few more.

Would the maintainers of this repo be open to reviewing a PR that would try to improve phrasing across (not reorganizing anything) the docs here to be a bit clearer and grammatically correct?