### PR TITLE
fix typo oAuth -> OAuth

### DIFF
--- a/content/developer/api/oauth.md
+++ b/content/developer/api/oauth.md
@@ -1,5 +1,5 @@
 ---
-title: oAuth
+title: OAuth
 weight: 1
 ---
 


### PR DESCRIPTION
Thanks for Wallabag, it's super! I [wrote up my initial experience of it](https://qmacro.org/blog/posts/2025/03/10/migrating-github-issue-based-url-bookmarks-to-wallabag/), including using the API, and noticed a small but significant typo and thought I'd offer a fix. Hope that's OK!
