### PR TITLE
More actionable Docker launch command in installation docs

### DIFF
--- a/content/admin/installation/installation.md
+++ b/content/admin/installation/installation.md
@@ -66,14 +66,19 @@ This service always ships the latest release of wallabag. [You can create your a
 
 ## Installation with Docker or Docker compose
 
-We provide you a Docker image to install wallabag easily. Have a look at
-our repository on [Docker Hub](https://hub.docker.com/r/wallabag/wallabag/) for more information.
-
 ### Command to launch container
 
+This example starts Wallabag at `http://localhost:8080` using SQLite backend and persists its data to Docker named volumes:
+
 ```bash
-docker pull wallabag/wallabag
+docker run \
+  -v wallabag-data:/var/www/wallabag/data \
+  -v wallabag-images:/var/www/wallabag/web/assets/images \
+  -p 8080:80 -e "SYMFONY__ENV__DOMAIN_NAME=http://localhost:8080" \
+  wallabag/wallabag
 ```
+
+The default username and password are `wallabag:wallabag`. For more information, see [Wallabag on Docker Hub](https://hub.docker.com/r/wallabag/wallabag/).
 
 ## Installation on Cloudron
 

--- a/content/admin/installation/installation.md
+++ b/content/admin/installation/installation.md
@@ -68,7 +68,7 @@ This service always ships the latest release of wallabag. [You can create your a
 
 ### Command to launch container
 
-This example starts Wallabag at `http://localhost:8080` using SQLite backend and persists its data to Docker named volumes:
+This example starts wallabag at `http://localhost:8080` using SQLite backend and persists its data to Docker named volumes:
 
 ```bash
 docker run \

--- a/content/admin/installation/installation.md
+++ b/content/admin/installation/installation.md
@@ -78,7 +78,7 @@ docker run \
   wallabag/wallabag
 ```
 
-The default username and password are `wallabag:wallabag`. For more information, see [Wallabag on Docker Hub](https://hub.docker.com/r/wallabag/wallabag/).
+The default username and password are `wallabag:wallabag`. For more information, see [wallabag on Docker Hub](https://hub.docker.com/r/wallabag/wallabag/).
 
 ## Installation on Cloudron
 


### PR DESCRIPTION
This improves the docker command to launch the container. The `docker pull` command only fetches the container, but does not launch it. As such, it is not very useful.

With the updated invocation a Docker user can quickly spin up a ~Wallabag~wallabag instance for evaluation. For that reason, I chose port 8080 on the host machine since port 80 is often already taken. The `SYMFONY__ENV__DOMAIN_NAME` then reflects the host machine port number, otherwise CSS styles and other assets are broken in the browser. Additionally, wallabag data is persisted using Docker named volumes instead of mounting absolute paths on the host machine that may not exist.

I've removed the “Have a look at our repository” note because it does not link to anything and, if someone does look at the ~Wallabag~wallabag repository on GitHub, there are no Docker instructions there and the reader will instead be pointed from there to this very documentation site.

Fixes https://github.com/wallabag/doc/issues/174