### PR TITLE
wrap database_path for SQLite between quotes

### DIFF
--- a/content/admin/installation/installation.md
+++ b/content/admin/installation/installation.md
@@ -23,7 +23,7 @@ You can have a look at [Symfony documentation](http://symfony.com/doc/current/co
 {{< /callout >}}
 
 {{< callout type="info" >}}
-If you want to use SQLite to store your data, please put `%kernel.root_dir%/../data/db/wallabag.sqlite` for the `database_path` parameter during installation.
+If you want to use SQLite to store your data, please put `"%kernel.root_dir%/../data/db/wallabag.sqlite"` for the `database_path` parameter during installation.
 {{< /callout >}}
 
 {{< callout type="info" >}}


### PR DESCRIPTION
To avoid an error, indicate the needed double quote in the information about database_path for SQLite installations.

This crash:
```
database_path (null): %kernel.root_dir%/../data/db/wallabag.sqlite
Script Incenteev\ParameterHandler\ScriptHandler::buildParameters handling the post-cmd event terminated with an exception

In Inline.php line 310:
                                                                                                                                                          
  The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 67 (near "%kernel.root_dir%/../data/db/wallabag.sqlite").
```

This don't:
```
database_path (null): "%kernel.root_dir%/../data/db/wallabag.sqlite"
```