### PR TITLE
Fix: Remove ?hl=fr from Chrome Wallabagger URL

### DIFF
--- a/content/user/articles/save.md
+++ b/content/user/articles/save.md
@@ -38,7 +38,7 @@ here](https://addons.mozilla.org/firefox/addon/wallabagger/).
 ### Chrome
 
 You can download the [Chrome addon
-here](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj?hl=fr).
+here](https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj).
 
 ### How to use our addon
 


### PR DESCRIPTION
The original link incorrectly specified the French locale, which is unnecessary for a universal link to the Chrome Web Store.